### PR TITLE
import manually created storage containers into state

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -37,6 +37,19 @@ data_lake_storage_containers = [
   "odw-config"
 ]
 
+containers_to_add = {
+  "insights-logs-builtinsqlreqsended" = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/insights-logs-builtinsqlreqsended"
+  "logging"                            = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/logging"
+  "odw-config-db"                      = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/odw-config-db"
+  "odw-curated-migration"             = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/odw-curated-migration"
+  "odw-standardised-delta"            = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/odw-standardised-delta"
+  "s51-advice-backup"                 = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/s51-advice-backup"
+  "saphrsdata-to-odw"                 = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/saphrsdata-to-odw"
+  "synapse"                            = "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Storage/storageAccounts/pinsstoddwdevuks9h80mb/blobServices/default/containers/synapse"
+}
+
+
+
 devops_agent_pool_resource_group_name          = "pins-rg-devops-odw-dev-uks"
 devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-dev-ukw"
 

--- a/infrastructure/modules/synapse-data-lake/data-lake.tf
+++ b/infrastructure/modules/synapse-data-lake/data-lake.tf
@@ -79,3 +79,10 @@ resource "azurerm_storage_container" "synapse" {
     azurerm_storage_data_lake_gen2_filesystem.synapse
   ]
 }
+
+import {
+  for_each = var.containers_to_add
+  to       = azurerm_storage_container.synapse[each.key]
+  id       = each.value
+}
+

--- a/infrastructure/modules/synapse-data-lake/variables.tf
+++ b/infrastructure/modules/synapse-data-lake/variables.tf
@@ -149,3 +149,9 @@ variable "external_resource_links_enabled" {
   description = "If connections and links to resources outside of the ODW should be made"
   type        = bool
 }
+
+variable "containers_to_add" {
+  description = "Manually created containers to be imported into state"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -27,6 +27,7 @@ module "synapse_data_lake" {
   data_lake_retention_days               = var.data_lake_retention_days
   data_lake_role_assignments             = var.data_lake_role_assignments
   data_lake_storage_containers           = var.data_lake_storage_containers
+  containers_to_add                      = var.containers_to_add
   devops_agent_subnet_name               = module.synapse_network.devops_agent_subnet_name
   firewall_allowed_ip_addresses          = local.firewall_allowed_ip_addresses
   function_app_principal_ids             = local.function_app_identity


### PR DESCRIPTION
[https://pins-ds.atlassian.net/browse/THEODW-2108](url)
- Added containers_to_add variable to enable dynamic container imports
- Declared import block in synapse-data-lake module to bring existing Azure Blob containers under Terraform management
- Updated workload-data-lake.tf to pass containers_to_add to both synapse_data_lake and synapse_data_lake_failover modules
- Defined container import values for the dev environment in environments/dev.tfvars

This allows Terraform to track manually created storage containers without recreating them.