### PR TITLE
feat: Add ODBC Driver 18 installation to DevOps agents

### DIFF
--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -54,7 +54,7 @@ sudo apt-get install -y --no-install-recommends \
 
 # Python dependencies
 ## Requirements for the tests
-sudo python3 -m pip install -r tests_requirements.txt
+sudo python3 -m pip install -r tests/requirements.txt
 
 # Install Poetry
 python3 -m pip install -U poetry==2.1.3
@@ -81,6 +81,14 @@ curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 # Azure Tools
 sudo curl -fsSL https://aka.ms/install-azd.sh | bash
+
+# Microsoft SQL Server ODBC Driver 18
+echo "Installing Microsoft SQL Server ODBC Driver 18..."
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
+sudo apt-get update
+sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+echo "ODBC Driver 18 installation completed"
 
 # .NET Core and PowerShell
 wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -14,7 +14,6 @@ sudo apt-get install -y --no-install-recommends \
   apt-transport-https \
   build-essential \
   ca-certificates \
-  unixodbc-dev \
   curl \
   gnupg \
   jq \
@@ -87,8 +86,9 @@ echo "Installing Microsoft SQL Server ODBC Driver 18..."
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
 sudo apt-get update
-sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
-echo "ODBC Driver 18 installation completed"
+# Install ODBC driver and development headers together
+sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev
+echo "ODBC Driver 18 and development headers installation completed"
 
 # .NET Core and PowerShell
 wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -82,7 +82,7 @@ curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 sudo curl -fsSL https://aka.ms/install-azd.sh | bash
 
 # Microsoft SQL Server ODBC Driver 18
-echo "Installing Microsoft SQL Server ODBC Driver 18..."
+echo "Installing Microsoft SQL Server ODBC Driver 18"
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
 sudo apt-get update


### PR DESCRIPTION
Prep work for [feat/THEODW-2123](https://pins-ds.atlassian.net/browse/THEODW-2123)
1. Added ODBC Driver 18 Installation:
•  Microsoft repository configuration
•  ODBC Driver 18 (msodbcsql18) installation with EULA acceptance
•  Proper error logging and confirmation messages

2. Removed Redundancy:
•  Removed unixodbc-dev from early package installation list
•  Consolidated ODBC-related installations in one logical section

3. Fixed Configuration:
•  Fixed path from tests_requirements.txt to tests/requirements.txt
•  Ensured proper installation of Python test dependencies