### PR TITLE
feat: Add explicit pyodbc installation to DevOps agents

### DIFF
--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -58,9 +58,6 @@ sudo python3 -m pip install -r tests_requirements.txt
 # Install Poetry
 python3 -m pip install -U poetry==2.1.3
 
-# Install pyodbc for ODBC database connectivity
-python3 -m pip install pyodbc
-
 # Terraform
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"


### PR DESCRIPTION
- Install pyodbc directly in DevOps agent setup script
- Ensures ODBC database connectivity is available for E2E tests
- Complements existing ODBC Driver 18 installation
- Resolves pyodbc import errors in test environments