### PR TITLE
Changes to import containers

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -37,6 +37,16 @@ data_lake_storage_containers = [
   "odw-config"
 ]
 
+data_lake_storage_containers_to_import = [
+  "insights-logs-builtinsqlreqsended",
+  "logging",
+  "odw-config-db",
+  "odw-curated-migration",
+  "odw-standardised-delta",
+  "s51-advice-backup",
+  "saphrspdata-to-odw"
+]
+
 devops_agent_pool_resource_group_name          = "pins-rg-devops-odw-dev-uks"
 devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-dev-ukw"
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -80,6 +80,12 @@ variable "data_lake_storage_containers" {
   type        = list(string)
 }
 
+variable "data_lake_storage_containers_to_import" {
+  default     = ["default"]
+  description = "A list of container names to be imported into the Synapse data lake Storage Account"
+  type        = list(string)
+}
+
 variable "deploy_agent_pool" {
   default     = true
   description = "A switch to determine whether the devops agent pool should be deployed"

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -26,7 +26,7 @@ module "synapse_data_lake" {
   data_lake_replication_type             = var.data_lake_replication_type
   data_lake_retention_days               = var.data_lake_retention_days
   data_lake_role_assignments             = var.data_lake_role_assignments
-  data_lake_storage_containers           = var.data_lake_storage_containers
+  data_lake_storage_containers           = concat(var.data_lake_storage_containers, var.data_lake_storage_containers_to_import)
   devops_agent_subnet_name               = module.synapse_network.devops_agent_subnet_name
   firewall_allowed_ip_addresses          = local.firewall_allowed_ip_addresses
   function_app_principal_ids             = local.function_app_identity
@@ -50,6 +50,12 @@ module "synapse_data_lake" {
     azurerm         = azurerm,
     azurerm.horizon = azurerm.horizon
   }
+}
+
+import {
+  for_each = toset(var.data_lake_storage_containers_to_import)
+  to       = module.synapse_data_lake.azurerm_storage_container.synapse[each.key]
+  id       = "https://${module.synapse_data_lake.data_lake_account_name}.blob.core.windows.net/${each.key}"
 }
 
 # module "synapse_data_lake_failover" {


### PR DESCRIPTION
[https://pins-ds.atlassian.net/browse/THEODW-2108](url)

This PR updates the ODW infrastructure to support importing manually created Azure Storage containers into Terraform state for the Synapse data lake.

- Added a list of existing storage containers (data_lake_storage_containers_to_import) that should be imported into Terraform state
- Introduced a new variable data_lake_storage_containers_to_import (default: ["default"]) with description and type definition.
- Concatenates data_lake_storage_containers with the new data_lake_storage_containers_to_import variable.
- Adds an import block to map each container to its corresponding resource in the Synapse Data Lake module using the correct Azure Storage container ID format

Run : 
[https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=130101&view=logs&j=0866595b-9b67-5953-e462-f841db7a2bb3&t=a8bc5641-f7cb-539b-9ddd-52345a2dda53](url)