### PR TITLE
Fix: Add TEAMS_WEBHOOK environment variable to add-keyvault-secrets step

### DIFF
--- a/pipelines/steps/add-keyvault-secrets.yaml
+++ b/pipelines/steps/add-keyvault-secrets.yaml
@@ -14,3 +14,5 @@ steps:
       fi
     displayName: 'Add keyvault secrets'
     name: AddKeyVaultSecrets
+    env:
+      TEAMS_WEBHOOK: $(TEAMS_WEBHOOK)


### PR DESCRIPTION
The pipeline was failing with 'ValueError: Could not find value for environment variable TEAMS_WEBHOOK' because the set_keyvault_secrets.py script expects this variable but it wasn't being passed through the pipeline step.

Changes:
- Added env section to add-keyvault-secrets.yaml to pass TEAMS_WEBHOOK variable

Additional configuration required:
- TEAMS_WEBHOOK must be added to Azure DevOps variable groups (Terraform Dev, Test, Build, Prod) as a secret variable

Resolves: THEODW-2807