### PR TITLE
fix(infrastructure): set max_message_size_in_kilobytes on Service Bus topics

### DIFF
--- a/infrastructure/modules/synapse-ingestion/locals.tf
+++ b/infrastructure/modules/synapse-ingestion/locals.tf
@@ -11,6 +11,7 @@ locals {
     enable_express                          = false
     enable_partitioning                     = false
     max_size_in_megabytes                   = 5120
+    max_message_size_in_kilobytes           = 1024
     requires_duplicate_detection            = false
     support_ordering                        = false
     subscriptions                           = {}

--- a/infrastructure/modules/synapse-ingestion/service-bus-topics.tf
+++ b/infrastructure/modules/synapse-ingestion/service-bus-topics.tf
@@ -11,6 +11,7 @@ resource "azurerm_servicebus_topic" "topics" {
   express_enabled                         = each.value.enable_express
   partitioning_enabled                    = each.value.enable_partitioning
   max_size_in_megabytes                   = each.value.max_size_in_megabytes
+  max_message_size_in_kilobytes           = each.value.max_message_size_in_kilobytes
   requires_duplicate_detection            = each.value.requires_duplicate_detection
   support_ordering                        = each.value.support_ordering
 }


### PR DESCRIPTION
## Summary

- Adds `max_message_size_in_kilobytes = 1024` (1 MB) as the default in `service_bus_topics_defaults` in `locals.tf`
- Wires the new field through to the `azurerm_servicebus_topic` resource in `service-bus-topics.tf`

Without this, topics silently fall back to the 256 KB standard-tier default even though all three namespaces (`dev`, `preprod`, `prod`) have `service_bus_premium_enabled = true`. Premium supports up to 100 MB per message; 1 MB is a safe starting point and can be overridden per-topic via the `service_bus_topics_and_subscriptions` variable.

## Test plan

- [ ] `terraform plan` in each environment shows an in-place update to existing topics setting `max_message_size_in_kilobytes = 1024`
- [ ] No resource replacements — this is a non-destructive attribute change
- [ ] `terraform apply` succeeds in dev before merging