### PR TITLE
Convert multiline comments to use hash

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -323,37 +323,37 @@ variable "odt_subscription_id" {
   description = "The subscription ID of the ODT subscription"
   type        = string
 }
-/*
-variable "openlineage_function_app" {
-  default = {
-    enabled               = false
-    function_app_receiver = ""
-    function_app_parser   = ""
-    site_config           = {}
-  }
-  description = "Determines whether the resources for the OpenLineage Function App should be deployed"
-  type = object({
-    enabled               = bool
-    function_app_receiver = string
-    function_app_parser   = string
-    site_config           = map(any)
-  })
-}
 
-variable "openlineage_storage_account" {
-  description = "Storage account, tables and  containers for openlineage POC"
-  type = object({
-    container_name = list(string)
-    tables         = list(string)
+# variable "openlineage_function_app" {
+#   default = {
+#     enabled               = false
+#     function_app_receiver = ""
+#     function_app_parser   = ""
+#     site_config           = {}
+#   }
+#   description = "Determines whether the resources for the OpenLineage Function App should be deployed"
+#   type = object({
+#     enabled               = bool
+#     function_app_receiver = string
+#     function_app_parser   = string
+#     site_config           = map(any)
+#   })
+# }
 
-  })
-  default = {
-    container_name = []
-    tables         = []
+# variable "openlineage_storage_account" {
+#   description = "Storage account, tables and  containers for openlineage POC"
+#   type = object({
+#     container_name = list(string)
+#     tables         = list(string)
 
-  }
-}
-*/
+#   })
+#   default = {
+#     container_name = []
+#     tables         = []
+
+#   }
+# }
+
 
 variable "apim_enabled" {
   default     = false

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -85,35 +85,35 @@ module "storage_account_failover" {
   ]
 }
 
-/*
-Commenting out because the current configuration is broken, and we may need something like this if the PoC goes ahead
 
-module "storage_account_openlineage" {
-  count = var.openlineage_function_app.enabled ? 1 : 0
+# Commenting out because the current configuration is broken, and we may need something like this if the PoC goes ahead
 
-  source = "./modules/storage-account"
+# module "storage_account_openlineage" {
+#   count = var.openlineage_function_app.enabled ? 1 : 0
 
-  resource_group_name                     = azurerm_resource_group.function_app[0].name
-  service_name                            = local.service_name
-  environment                             = var.environment
-  location                                = module.azure_region.location_cli
-  tags                                    = local.tags
-  network_rules_enabled                   = true
-  network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
-  container_name                          = var.openlineage_storage_account.container_name
-  tables                                  = var.openlineage_storage_account.tables
-  shares = [
-    {
-      name  = var.openlineage_function_app.function_app_receiver
-      quota = 5120
-    },
-    {
-      name  = var.openlineage_function_app.function_app_parser
-      quota = 5120
-    }
-  ]
-}
-*/
+#   source = "./modules/storage-account"
+
+#   resource_group_name                     = azurerm_resource_group.function_app[0].name
+#   service_name                            = local.service_name
+#   environment                             = var.environment
+#   location                                = module.azure_region.location_cli
+#   tags                                    = local.tags
+#   network_rules_enabled                   = true
+#   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
+#   container_name                          = var.openlineage_storage_account.container_name
+#   tables                                  = var.openlineage_storage_account.tables
+#   shares = [
+#     {
+#       name  = var.openlineage_function_app.function_app_receiver
+#       quota = 5120
+#     },
+#     {
+#       name  = var.openlineage_function_app.function_app_parser
+#       quota = 5120
+#     }
+#   ]
+# }
+
 
 module "function_app" {
   for_each = {
@@ -167,57 +167,57 @@ module "function_app_failover" {
   servicebus_namespace       = var.odt_back_office_service_bus_name
 }
 
-/*
-module "function_app_openlineage_receiver" {
-  count = var.openlineage_function_app.enabled ? 1 : 0
 
-  source = "./modules/function-app"
+# module "function_app_openlineage_receiver" {
+#   count = var.openlineage_function_app.enabled ? 1 : 0
 
-  resource_group_name          = azurerm_resource_group.function_app[0].name
-  function_app_name            = var.openlineage_function_app.function_app_receiver
-  service_name                 = local.service_name
-  service_plan_id              = module.service_plan[0].id
-  environment                  = var.environment
-  location                     = module.azure_region.location_cli
-  tags                         = local.tags
-  synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
-  app_settings                 = null
-  site_config                  = var.openlineage_function_app.site_config
-  application_insights_key     = azurerm_application_insights.function_app_insights["fnapp01"].instrumentation_key
-  file_share_name              = "pins-${var.openlineage_function_app.function_app_receiver}-${local.resource_suffix}"
-  servicebus_namespace         = var.odt_back_office_service_bus_name
-  servicebus_namespace_appeals = var.odt_appeals_back_office.service_bus_name
-  message_storage_account      = var.message_storage_account
-  message_storage_container    = var.message_storage_container
-  storage_account_name         = module.storage_account_openlineage[0].storage_name
-  storage_account_access_key   = module.storage_account_openlineage[0].primary_access_key
-}
+#   source = "./modules/function-app"
 
-module "function_app_openlineage_parser" {
-  count = var.openlineage_function_app.enabled ? 1 : 0
+#   resource_group_name          = azurerm_resource_group.function_app[0].name
+#   function_app_name            = var.openlineage_function_app.function_app_receiver
+#   service_name                 = local.service_name
+#   service_plan_id              = module.service_plan[0].id
+#   environment                  = var.environment
+#   location                     = module.azure_region.location_cli
+#   tags                         = local.tags
+#   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
+#   app_settings                 = null
+#   site_config                  = var.openlineage_function_app.site_config
+#   application_insights_key     = azurerm_application_insights.function_app_insights["fnapp01"].instrumentation_key
+#   file_share_name              = "pins-${var.openlineage_function_app.function_app_receiver}-${local.resource_suffix}"
+#   servicebus_namespace         = var.odt_back_office_service_bus_name
+#   servicebus_namespace_appeals = var.odt_appeals_back_office.service_bus_name
+#   message_storage_account      = var.message_storage_account
+#   message_storage_container    = var.message_storage_container
+#   storage_account_name         = module.storage_account_openlineage[0].storage_name
+#   storage_account_access_key   = module.storage_account_openlineage[0].primary_access_key
+# }
 
-  source = "./modules/function-app"
+# module "function_app_openlineage_parser" {
+#   count = var.openlineage_function_app.enabled ? 1 : 0
 
-  resource_group_name          = azurerm_resource_group.function_app[0].name
-  function_app_name            = var.openlineage_function_app.function_app_parser
-  service_name                 = local.service_name
-  service_plan_id              = module.service_plan[0].id
-  environment                  = var.environment
-  location                     = module.azure_region.location_cli
-  tags                         = local.tags
-  synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
-  app_settings                 = null
-  site_config                  = var.openlineage_function_app.site_config
-  application_insights_key     = azurerm_application_insights.function_app_insights["fnapp01"].instrumentation_key
-  file_share_name              = "pins-${var.openlineage_function_app.function_app_parser}-${local.resource_suffix}"
-  servicebus_namespace         = var.odt_back_office_service_bus_name
-  servicebus_namespace_appeals = var.odt_appeals_back_office.service_bus_name
-  message_storage_account      = var.message_storage_account
-  message_storage_container    = var.message_storage_container
-  storage_account_name         = module.storage_account_openlineage[0].storage_name
-  storage_account_access_key   = module.storage_account_openlineage[0].primary_access_key
-}
-*/
+#   source = "./modules/function-app"
+
+#   resource_group_name          = azurerm_resource_group.function_app[0].name
+#   function_app_name            = var.openlineage_function_app.function_app_parser
+#   service_name                 = local.service_name
+#   service_plan_id              = module.service_plan[0].id
+#   environment                  = var.environment
+#   location                     = module.azure_region.location_cli
+#   tags                         = local.tags
+#   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
+#   app_settings                 = null
+#   site_config                  = var.openlineage_function_app.site_config
+#   application_insights_key     = azurerm_application_insights.function_app_insights["fnapp01"].instrumentation_key
+#   file_share_name              = "pins-${var.openlineage_function_app.function_app_parser}-${local.resource_suffix}"
+#   servicebus_namespace         = var.odt_back_office_service_bus_name
+#   servicebus_namespace_appeals = var.odt_appeals_back_office.service_bus_name
+#   message_storage_account      = var.message_storage_account
+#   message_storage_container    = var.message_storage_container
+#   storage_account_name         = module.storage_account_openlineage[0].storage_name
+#   storage_account_access_key   = module.storage_account_openlineage[0].primary_access_key
+# }
+
 
 resource "azurerm_role_assignment" "odt_servicebus_namespace" {
   for_each = {


### PR DESCRIPTION
Updates the approach for multiline comments to fix a CI failures caused by an update to tflint