### PR TITLE
FEAT/THEODW-3079: Add Crown Dev service bus topic

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -206,7 +206,7 @@ service_bus_topics_and_subscriptions = [
     name = "application-update"
     subscriptions = {
       "planning-environmental-specialist-odw-sub" = {},
-      "application-update-odw-wake-sub"           = {}
+      "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }
 ]

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -205,7 +205,7 @@ service_bus_topics_and_subscriptions = [
   {
     name = "application-update"
     subscriptions = {
-      "planning-environmental-specialist-odw-sub"      = {},
+      "planning-environmental-specialist-odw-sub" = {},
       "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -205,7 +205,7 @@ service_bus_topics_and_subscriptions = [
   {
     name = "application-update"
     subscriptions = {
-      "planning-environmental-specialist-odw-sub" = {},
+      "planning-environmental-specialist-odw-sub"      = {},
       "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -170,7 +170,7 @@ service_bus_topics_and_subscriptions = [
   {
     name = "application-update"
     subscriptions = {
-      "planning-environmental-specialist-odw-sub"      = {},
+      "planning-environmental-specialist-odw-sub" = {},
       "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -170,7 +170,7 @@ service_bus_topics_and_subscriptions = [
   {
     name = "application-update"
     subscriptions = {
-      "planning-environmental-specialist-odw-sub" = {},
+      "planning-environmental-specialist-odw-sub"      = {},
       "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -171,7 +171,7 @@ service_bus_topics_and_subscriptions = [
     name = "application-update"
     subscriptions = {
       "planning-environmental-specialist-odw-sub" = {},
-      "application-update-odw-wake-sub"           = {}
+      "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }
 ]


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3079

Changed topic for new entity application-update within the dev and test terraform files, so that consistent naming convention is followed through, with the new topic object being:

name: application-update
subscriptions mapping: planning-environmental-specialist-odw-sub (drain subscription) and planning-environmental-specialist-odw-wake-sub (wake subscription)