### PR TITLE
fix/disable application-update

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -201,13 +201,6 @@ service_bus_topics_and_subscriptions = [
   {
     name          = "pins-inspector"
     subscriptions = {}
-  },
-  {
-    name = "application-update"
-    subscriptions = {
-      "planning-environmental-specialist-odw-sub"      = {},
-      "planning-environmental-specialist-odw-wake-sub" = {}
-    }
   }
 ]
 

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -166,13 +166,6 @@ service_bus_topics_and_subscriptions = [
   {
     name          = "pins-inspector"
     subscriptions = {}
-  },
-  {
-    name = "application-update"
-    subscriptions = {
-      "planning-environmental-specialist-odw-sub"      = {},
-      "planning-environmental-specialist-odw-wake-sub" = {}
-    }
   }
 ]
 


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3079?focusedCommentId=121787

Temporarily disables application-update in DEV to stop repeated App Insights errors caused by a missing wake subscription. The function is currently trying to access application-update/Subscriptions/planning-environmental-specialist-odw-wake-sub in the pins-sb-back-office-dev-ukw-001 namespace, which is returning 404 MessagingEntityNotFound. Disabling it prevents further noise and failed lookups until the intended ServiceBus namespace and subscription configuration for application-update is confirmed and correct.