### PR TITLE
Add application update service bus topic and subscription

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -201,6 +201,13 @@ service_bus_topics_and_subscriptions = [
   {
     name          = "pins-inspector"
     subscriptions = {}
+  },
+  {
+    name = "application-update"
+    subscriptions = {
+      "planning-environmental-specialist-odw-sub" = {},
+      "planning-environmental-specialist-odw-wake-sub" = {}
+    }
   }
 ]
 

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -205,7 +205,7 @@ service_bus_topics_and_subscriptions = [
   {
     name = "application-update"
     subscriptions = {
-      "planning-environmental-specialist-odw-sub" = {},
+      "planning-environmental-specialist-odw-sub"      = {},
       "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -170,7 +170,7 @@ service_bus_topics_and_subscriptions = [
   {
     name = "application-update"
     subscriptions = {
-      "planning-environmental-specialist-odw-sub" = {},
+      "planning-environmental-specialist-odw-sub"      = {},
       "planning-environmental-specialist-odw-wake-sub" = {}
     }
   }

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -166,6 +166,13 @@ service_bus_topics_and_subscriptions = [
   {
     name          = "pins-inspector"
     subscriptions = {}
+  },
+  {
+    name = "application-update"
+    subscriptions = {
+      "planning-environmental-specialist-odw-sub" = {},
+      "planning-environmental-specialist-odw-wake-sub" = {}
+    }
   }
 ]
 

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -17,6 +17,7 @@ locals {
     {
       ServiceBusConnection__fullyQualifiedNamespace        = "${var.servicebus_namespace}.servicebus.windows.net"
       ServiceBusConnectionAppeals__fullyQualifiedNamespace = "${var.servicebus_namespace_appeals}.servicebus.windows.net"
+      ServiceBusConnectionOdw__fullyQualifiedNamespace     = "${var.servicebus_namespace_odw}.servicebus.windows.net"
       "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"           = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key};EndpointSuffix=core.windows.net"
       "WEBSITE_CONTENTSHARE"                               = var.file_share_name
       "WEBSITE_CONTENTOVERVNET"                            = 1

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -17,7 +17,7 @@ locals {
     {
       ServiceBusConnection__fullyQualifiedNamespace        = "${var.servicebus_namespace}.servicebus.windows.net"
       ServiceBusConnectionAppeals__fullyQualifiedNamespace = "${var.servicebus_namespace_appeals}.servicebus.windows.net"
-      ServiceBusConnectionOdw__fullyQualifiedNamespace     = "${var.servicebus_namespace_odw}.servicebus.windows.net"
+      ServiceBusConnectionOdw__fullyQualifiedNamespace     = var.servicebus_namespace_odw != null ? "${var.servicebus_namespace_odw}.servicebus.windows.net" : null
       "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"           = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key};EndpointSuffix=core.windows.net"
       "WEBSITE_CONTENTSHARE"                               = var.file_share_name
       "WEBSITE_CONTENTOVERVNET"                            = 1

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -118,6 +118,12 @@ variable "servicebus_namespace_appeals" {
   default     = null
 }
 
+variable "servicebus_namespace_odw" {
+  type        = string
+  description = "The name of the ODW service bus namespace to use for the function app"
+  default     = null
+}
+
 variable "site_config_defaults" {
   type = object({
     always_on = bool

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -137,6 +137,7 @@ module "function_app" {
   file_share_name              = "pins-${each.key}-${local.resource_suffix}"
   servicebus_namespace         = var.odt_back_office_service_bus_name
   servicebus_namespace_appeals = var.odt_appeals_back_office.service_bus_name
+  servicebus_namespace_odw     = module.synapse_ingestion.service_bus_namespace_name
   message_storage_account      = var.message_storage_account
   message_storage_container    = var.message_storage_container
 }
@@ -163,6 +164,7 @@ module "function_app_failover" {
   site_config                = each.value.site_config
   file_share_name            = "pins-${each.key}-${local.resource_suffix_failover}"
   servicebus_namespace       = var.odt_back_office_service_bus_name
+  servicebus_namespace_odw   = var.service_bus_failover_enabled ? module.synapse_ingestion_failover[0].service_bus_namespace_name : module.synapse_ingestion.service_bus_namespace_name
 }
 
 # module "function_app_openlineage_receiver" {
@@ -231,6 +233,16 @@ resource "azurerm_role_assignment" "odt_appeals_servicebus_namespace" {
   }
 
   scope                = local.odt_appeals_back_office_service_bus_id
+  role_definition_name = "Azure Service Bus Data receiver"
+  principal_id         = module.function_app[each.key].identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "odw_servicebus_namespace" {
+  for_each = {
+    for function_app in var.function_app : function_app.name => function_app if var.function_app_enabled == true
+  }
+
+  scope                = module.synapse_ingestion.service_bus_namespace_id
   role_definition_name = "Azure Service Bus Data receiver"
   principal_id         = module.function_app[each.key].identity[0].principal_id
 }


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3079?search_id=29fcf05d-89aa-4155-8a77-12488a10b663

The function app had no knowledge of the ODW service bus namespace, so any entity routed to ServiceBusConnectionOdw would fail at runtime as the app setting didn't exist. 

1. Added topic for new entity application-update within the dev and test terraform files, with the new topic object being:
name: application-update
subscriptions mapping: planning-environmental-specialist-odw-sub (drain subscription) and planning-environmental-specialist-odw-wake-sub (wake subscription)
2. New module input: added `servicebus_namespace_odw` variable to the function-app module to accept the ODW service bus namespace name
3. New app setting: exposes `ServiceBusConnectionOdw__fullyQualifiedNamespace` as a function app config setting, constructed from the input var 
4. Module wiring - primary + failover:
Primary: passes `module.synapse_ingestion.service_bus_namespace_name` directly and reuses exisitng module output
Failover: conditionally passes failover namespace when `service_bus_failover_enabled` is true, otherwise falls back to primary namespace
5. RBAC: grants function app managed identity, the relevant role on the ODW namespace and scoped to all function app instances via for_each
