### PR TITLE
fix: remove FunctionAppLogs diagnostic setting to stop double Log Analytics ingestion

### DIFF
--- a/infrastructure/modules/synapse-monitoring/monitor-function-app.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-function-app.tf
@@ -6,10 +6,6 @@ resource "azurerm_monitor_diagnostic_setting" "function_app" {
   log_analytics_workspace_id = azurerm_log_analytics_workspace.synapse.id
 
 
-  enabled_log {
-    category = "FunctionAppLogs"
-  }
-
   metric {
     category = "AllMetrics"
   }


### PR DESCRIPTION
## Summary

- Removes the `FunctionAppLogs` `enabled_log` block from `azurerm_monitor_diagnostic_setting.function_app` in `modules/synapse-monitoring/monitor-function-app.tf`
- `AllMetrics` is retained — metrics are not duplicated by Application Insights
- No other diagnostic categories are affected

## Context

Part of THEODW-3322 / THEODW-3291. The Function App telemetry was reaching Log Analytics via two independent paths simultaneously:

1. **Application Insights (workspace-based)** — `azurerm_application_insights.function_app_insights` in `workload-function-app.tf` has `workspace_id` pointing to the Log Analytics workspace, which automatically exports all traces, exceptions, requests and dependencies
2. **Diagnostic Setting** — `azurerm_monitor_diagnostic_setting.function_app` was also sending `FunctionAppLogs` to the same workspace

Every log entry was therefore written to Log Analytics twice, doubling baseline ingestion volume before any per-message log amplification was considered. Removing `FunctionAppLogs` from the diagnostic setting eliminates the duplicate path; Application Insights remains the single export route.

See companion PR in odw-azure-functions for the application-level log reduction change.

## Test plan

- [ ] Apply Terraform plan and confirm the diagnostic setting no longer includes `FunctionAppLogs`
- [ ] After a representative test run, confirm `FunctionAppLogs` table in Log Analytics no longer contains function worker traces
- [ ] Confirm `AppTraces` (via Application Insights) still receives the expected WAKE_DRAIN log entries
- [ ] Confirm `AllMetrics` data continues to appear in Log Analytics as expected