### PR TITLE
feat: adding prod tags for vulnerable resources

### DIFF
--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -49,7 +49,7 @@ devops_agent_pool_resource_group_name          = "pins-rg-devops-odw-prod-uks"
 devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-prod-ukw"
 
 environment = "prod"
-system_asset_owner = "pins-odw-prod-administrators"
+system_asset_owner = "dummy-data"
 
 function_app_enabled = true
 function_app = [
@@ -279,4 +279,3 @@ vnet_subnets = [
 external_resource_links_enabled = true
 
 link_purview_account = true
-

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -49,6 +49,7 @@ devops_agent_pool_resource_group_name          = "pins-rg-devops-odw-prod-uks"
 devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-prod-ukw"
 
 environment = "prod"
+system_asset_owner = "pins-odw-prod-administrators"
 
 function_app_enabled = true
 function_app = [

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -50,8 +50,6 @@ devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-prod-ukw"
 
 environment = "prod"
 
-system_asset_owner = "dummy-data"
-
 function_app_enabled = true
 function_app = [
   {

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -49,6 +49,7 @@ devops_agent_pool_resource_group_name          = "pins-rg-devops-odw-prod-uks"
 devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-prod-ukw"
 
 environment = "prod"
+
 system_asset_owner = "dummy-data"
 
 function_app_enabled = true

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -29,16 +29,17 @@ locals {
       CreatedBy   = "Terraform"
       Environment = var.environment
       ServiceName = local.service_name
-    },
-    var.environment == "prod" ? {
-      SystemAssetOwner    = var.system_asset_owner
-      BusinessProcess     = "ODW"
-      PersonalData        = "No"
-      SpecialCategoryData = "No"
-      ProtectiveMarking   = "Official-Sensitive-Mission-Critical"
-      CriticalityRating   = "Level 2"
-    } : {}
+    }
   )
+
+  prod_tags = var.environment == "prod" ? {
+    SystemAssetOwner    = var.system_asset_owner
+    BusinessProcess     = "ODW"
+    PersonalData        = "No"
+    SpecialCategoryData = "No"
+    ProtectiveMarking   = "Official-Sensitive-Mission-Critical"
+    CriticalityRating   = "Level 2"
+  } : {}
 
   tooling_storage_dns_zone_ids = {
     for zone in toset(local.storage_zones) : zone => data.azurerm_private_dns_zone.tooling_storage[zone].id

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -32,7 +32,6 @@ locals {
     }
   )
 
-
   prod_tags = var.environment == "prod" ? {
     SystemAssetOwner    = var.system_asset_owner
     BusinessProcess     = "ODW"

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -29,17 +29,16 @@ locals {
       CreatedBy   = "Terraform"
       Environment = var.environment
       ServiceName = local.service_name
-    }
+    },
+    var.environment == "prod" ? {
+      SystemAssetOwner    = var.system_asset_owner
+      BusinessProcess     = "ODW"
+      PersonalData        = "No"
+      SpecialCategoryData = "No"
+      ProtectiveMarking   = "Official-Sensitive-Mission-Critical"
+      CriticalityRating   = "Level 2"
+    } : {}
   )
-
-  prod_tags = var.environment == "prod" ? {
-    SystemAssetOwner    = var.system_asset_owner
-    BusinessProcess     = "ODW"
-    PersonalData        = "No"
-    SpecialCategoryData = "No"
-    ProtectiveMarking   = "Official-Sensitive-Mission-Critical"
-    CriticalityRating   = "Level 2"
-  } : {}
 
   tooling_storage_dns_zone_ids = {
     for zone in toset(local.storage_zones) : zone => data.azurerm_private_dns_zone.tooling_storage[zone].id

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -32,6 +32,7 @@ locals {
     }
   )
 
+
   prod_tags = var.environment == "prod" ? {
     SystemAssetOwner    = var.system_asset_owner
     BusinessProcess     = "ODW"

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -29,7 +29,15 @@ locals {
       CreatedBy   = "Terraform"
       Environment = var.environment
       ServiceName = local.service_name
-    }
+    },
+    var.environment == "prod" ? {
+      SystemAssetOwner    = var.system_asset_owner
+      BusinessProcess     = "ODW"
+      PersonalData        = "No"
+      SpecialCategoryData = "No"
+      ProtectiveMarking   = "Official-Sensitive-Mission-Critical"
+      CriticalityRating   = "Level 2"
+    } : {}
   )
 
   tooling_storage_dns_zone_ids = {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -676,6 +676,7 @@ variable "purview_storage_id" {
   default     = null
 }
 
+
 variable "purview_event_hub_id" {
   description = "The id of Purview's managed event hub"
   type        = string
@@ -692,6 +693,12 @@ variable "specialist_case_validation_check_recipients" {
   description = "Semicolon-separates list of email addresses"
   type        = string
   default     = ""
+}
+
+variable "system_asset_owner" {
+  description = "tagging - value extracted from ADO library secret"
+  type        = string
+  sensitive   = true
 }
 
 variable "specialist_case_validation_check_logic_app_migration_ids" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -676,7 +676,6 @@ variable "purview_storage_id" {
   default     = null
 }
 
-
 variable "purview_event_hub_id" {
   description = "The id of Purview's managed event hub"
   type        = string

--- a/infrastructure/workload-agent-pool.tf
+++ b/infrastructure/workload-agent-pool.tf
@@ -13,7 +13,7 @@ module "devops_agent_pool" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "devops_agent_pool_failover" {
@@ -32,7 +32,7 @@ module "devops_agent_pool_failover" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 moved {

--- a/infrastructure/workload-agent-pool.tf
+++ b/infrastructure/workload-agent-pool.tf
@@ -13,10 +13,7 @@ module "devops_agent_pool" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "devops_agent_pool_failover" {
@@ -35,10 +32,7 @@ module "devops_agent_pool_failover" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 moved {

--- a/infrastructure/workload-agent-pool.tf
+++ b/infrastructure/workload-agent-pool.tf
@@ -13,7 +13,7 @@ module "devops_agent_pool" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "devops_agent_pool_failover" {
@@ -32,7 +32,7 @@ module "devops_agent_pool_failover" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network_failover.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 moved {

--- a/infrastructure/workload-agent-pool.tf
+++ b/infrastructure/workload-agent-pool.tf
@@ -13,7 +13,7 @@ module "devops_agent_pool" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "devops_agent_pool_failover" {
@@ -32,7 +32,7 @@ module "devops_agent_pool_failover" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 moved {

--- a/infrastructure/workload-agent-pool.tf
+++ b/infrastructure/workload-agent-pool.tf
@@ -13,7 +13,10 @@ module "devops_agent_pool" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network.vnet_subnets
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "devops_agent_pool_failover" {
@@ -32,7 +35,10 @@ module "devops_agent_pool_failover" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network_failover.vnet_subnets
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 moved {

--- a/infrastructure/workload-api-manangement.tf
+++ b/infrastructure/workload-api-manangement.tf
@@ -3,7 +3,10 @@ resource "azurerm_resource_group" "api_management" {
   name     = "pins-rg-apim-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "api_management_failover" {
@@ -12,7 +15,10 @@ resource "azurerm_resource_group" "api_management_failover" {
   name     = "pins-rg-apim-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "api_management" {
@@ -33,7 +39,10 @@ module "api_management" {
   synapse_vnet_subnet_names = module.synapse_network.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "api_management_failover" {
@@ -54,5 +63,8 @@ module "api_management_failover" {
   synapse_vnet_subnet_names = module.synapse_network_failover.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }

--- a/infrastructure/workload-api-manangement.tf
+++ b/infrastructure/workload-api-manangement.tf
@@ -3,7 +3,7 @@ resource "azurerm_resource_group" "api_management" {
   name     = "pins-rg-apim-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "api_management_failover" {
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "api_management_failover" {
   name     = "pins-rg-apim-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "api_management" {
@@ -33,7 +33,7 @@ module "api_management" {
   synapse_vnet_subnet_names = module.synapse_network.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "api_management_failover" {
@@ -54,5 +54,5 @@ module "api_management_failover" {
   synapse_vnet_subnet_names = module.synapse_network_failover.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-api-manangement.tf
+++ b/infrastructure/workload-api-manangement.tf
@@ -3,7 +3,7 @@ resource "azurerm_resource_group" "api_management" {
   name     = "pins-rg-apim-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "api_management_failover" {
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "api_management_failover" {
   name     = "pins-rg-apim-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "api_management" {
@@ -33,7 +33,7 @@ module "api_management" {
   synapse_vnet_subnet_names = module.synapse_network.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "api_management_failover" {
@@ -54,5 +54,5 @@ module "api_management_failover" {
   synapse_vnet_subnet_names = module.synapse_network_failover.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-api-manangement.tf
+++ b/infrastructure/workload-api-manangement.tf
@@ -3,7 +3,7 @@ resource "azurerm_resource_group" "api_management" {
   name     = "pins-rg-apim-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "api_management_failover" {
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "api_management_failover" {
   name     = "pins-rg-apim-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "api_management" {
@@ -33,7 +33,7 @@ module "api_management" {
   synapse_vnet_subnet_names = module.synapse_network.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "api_management_failover" {
@@ -54,5 +54,5 @@ module "api_management_failover" {
   synapse_vnet_subnet_names = module.synapse_network_failover.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-api-manangement.tf
+++ b/infrastructure/workload-api-manangement.tf
@@ -3,10 +3,7 @@ resource "azurerm_resource_group" "api_management" {
   name     = "pins-rg-apim-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "api_management_failover" {
@@ -15,10 +12,7 @@ resource "azurerm_resource_group" "api_management_failover" {
   name     = "pins-rg-apim-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "api_management" {
@@ -39,10 +33,7 @@ module "api_management" {
   synapse_vnet_subnet_names = module.synapse_network.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "api_management_failover" {
@@ -63,8 +54,5 @@ module "api_management_failover" {
   synapse_vnet_subnet_names = module.synapse_network_failover.vnet_subnets
   #synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -2,20 +2,14 @@ resource "azurerm_resource_group" "data" {
   name     = "pins-rg-data-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "data_failover" {
   name     = "pins-rg-data-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_data_lake" {
@@ -49,10 +43,7 @@ module "synapse_data_lake" {
   vnet_subnet_ids_failover = module.synapse_network_failover.vnet_subnets
 
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 
   providers = {
     azurerm         = azurerm,

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -2,14 +2,14 @@ resource "azurerm_resource_group" "data" {
   name     = "pins-rg-data-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "data_failover" {
   name     = "pins-rg-data-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_data_lake" {
@@ -43,7 +43,7 @@ module "synapse_data_lake" {
   vnet_subnet_ids_failover = module.synapse_network_failover.vnet_subnets
 
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 
   providers = {
     azurerm         = azurerm,
@@ -106,7 +106,7 @@ import {
 #   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 #   vnet_subnet_ids_failover = module.synapse_network.vnet_subnets
 
-#   tags = merge(local.tags, local.prod_tags)
+#   tags = merge(local.tags, var.environment == "prod")
 
 #   providers = {
 #     azurerm         = azurerm,

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -2,14 +2,14 @@ resource "azurerm_resource_group" "data" {
   name     = "pins-rg-data-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "data_failover" {
   name     = "pins-rg-data-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_data_lake" {
@@ -43,7 +43,7 @@ module "synapse_data_lake" {
   vnet_subnet_ids_failover = module.synapse_network_failover.vnet_subnets
 
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm         = azurerm,
@@ -106,7 +106,7 @@ import {
 #   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 #   vnet_subnet_ids_failover = module.synapse_network.vnet_subnets
 
-#   tags = merge(local.tags, var.environment == "prod")
+#   tags = merge(local.tags, local.prod_tags)
 
 #   providers = {
 #     azurerm         = azurerm,

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -2,14 +2,20 @@ resource "azurerm_resource_group" "data" {
   name     = "pins-rg-data-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "data_failover" {
   name     = "pins-rg-data-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_data_lake" {
@@ -42,7 +48,11 @@ module "synapse_data_lake" {
   vnet_subnet_ids          = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover = module.synapse_network_failover.vnet_subnets
 
-  tags = local.tags
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 
   providers = {
     azurerm         = azurerm,

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -2,14 +2,14 @@ resource "azurerm_resource_group" "data" {
   name     = "pins-rg-data-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "data_failover" {
   name     = "pins-rg-data-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_data_lake" {
@@ -43,7 +43,7 @@ module "synapse_data_lake" {
   vnet_subnet_ids_failover = module.synapse_network_failover.vnet_subnets
 
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm         = azurerm,
@@ -106,7 +106,7 @@ import {
 #   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 #   vnet_subnet_ids_failover = module.synapse_network.vnet_subnets
 
-#   tags = local.tags
+#   tags = merge(local.tags, local.prod_tags)
 
 #   providers = {
 #     azurerm         = azurerm,

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "function_app" {
   name     = "pins-rg-function-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "function_app_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "function_app_failover" {
   name     = "pins-rg-function-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "service_plan" {
@@ -26,7 +26,7 @@ module "service_plan" {
   environment         = var.environment
   location            = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "service_plan_failover" {
@@ -39,7 +39,7 @@ module "service_plan_failover" {
   environment         = var.environment
   location            = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "storage_account" {
@@ -62,7 +62,7 @@ module "storage_account" {
     }
   ]
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 
@@ -86,7 +86,7 @@ module "storage_account_failover" {
     }
   ]
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 # Commenting out because the current configuration is broken, and we may need
@@ -144,7 +144,7 @@ module "function_app" {
   message_storage_account      = var.message_storage_account
   message_storage_container    = var.message_storage_container
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "function_app_failover" {
@@ -170,7 +170,7 @@ module "function_app_failover" {
   servicebus_namespace       = var.odt_back_office_service_bus_name
   servicebus_namespace_odw   = var.service_bus_failover_enabled ? module.synapse_ingestion_failover[0].service_bus_namespace_name : module.synapse_ingestion.service_bus_namespace_name
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 # module "function_app_openlineage_receiver" {

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "function_app" {
   name     = "pins-rg-function-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "function_app_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "function_app_failover" {
   name     = "pins-rg-function-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "service_plan" {
@@ -26,7 +26,7 @@ module "service_plan" {
   environment         = var.environment
   location            = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "service_plan_failover" {
@@ -39,7 +39,7 @@ module "service_plan_failover" {
   environment         = var.environment
   location            = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "storage_account" {
@@ -62,7 +62,7 @@ module "storage_account" {
     }
   ]
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 
@@ -86,7 +86,7 @@ module "storage_account_failover" {
     }
   ]
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 # Commenting out because the current configuration is broken, and we may need
@@ -144,7 +144,7 @@ module "function_app" {
   message_storage_account      = var.message_storage_account
   message_storage_container    = var.message_storage_container
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "function_app_failover" {
@@ -170,7 +170,7 @@ module "function_app_failover" {
   servicebus_namespace       = var.odt_back_office_service_bus_name
   servicebus_namespace_odw   = var.service_bus_failover_enabled ? module.synapse_ingestion_failover[0].service_bus_namespace_name : module.synapse_ingestion.service_bus_namespace_name
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 # module "function_app_openlineage_receiver" {

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "function_app" {
   name     = "pins-rg-function-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "function_app_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "function_app_failover" {
   name     = "pins-rg-function-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "service_plan" {
@@ -26,7 +26,7 @@ module "service_plan" {
   environment         = var.environment
   location            = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "service_plan_failover" {
@@ -39,7 +39,7 @@ module "service_plan_failover" {
   environment         = var.environment
   location            = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "storage_account" {
@@ -62,7 +62,7 @@ module "storage_account" {
     }
   ]
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 
@@ -86,7 +86,7 @@ module "storage_account_failover" {
     }
   ]
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 # Commenting out because the current configuration is broken, and we may need
@@ -144,7 +144,7 @@ module "function_app" {
   message_storage_account      = var.message_storage_account
   message_storage_container    = var.message_storage_container
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "function_app_failover" {
@@ -170,7 +170,7 @@ module "function_app_failover" {
   servicebus_namespace       = var.odt_back_office_service_bus_name
   servicebus_namespace_odw   = var.service_bus_failover_enabled ? module.synapse_ingestion_failover[0].service_bus_namespace_name : module.synapse_ingestion.service_bus_namespace_name
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 # module "function_app_openlineage_receiver" {

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -4,7 +4,10 @@ resource "azurerm_resource_group" "function_app" {
   name     = "pins-rg-function-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "function_app_failover" {
@@ -13,7 +16,10 @@ resource "azurerm_resource_group" "function_app_failover" {
   name     = "pins-rg-function-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "service_plan" {
@@ -25,7 +31,11 @@ module "service_plan" {
   service_name        = local.service_name
   environment         = var.environment
   location            = module.azure_region.location_cli
-  tags                = local.tags
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "service_plan_failover" {
@@ -37,7 +47,11 @@ module "service_plan_failover" {
   service_name        = local.service_name
   environment         = var.environment
   location            = module.azure_region.paired_location.location_cli
-  tags                = local.tags
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "storage_account" {
@@ -51,7 +65,6 @@ module "storage_account" {
   service_name                            = local.service_name
   environment                             = var.environment
   location                                = module.azure_region.location_cli
-  tags                                    = local.tags
   network_rules_enabled                   = true
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
   shares = [
@@ -60,6 +73,11 @@ module "storage_account" {
       quota = 5120
     }
   ]
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 
@@ -74,7 +92,6 @@ module "storage_account_failover" {
   service_name                            = local.service_name
   environment                             = var.environment
   location                                = module.azure_region.paired_location.location_cli
-  tags                                    = local.tags
   network_rules_enabled                   = true
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network_failover.vnet_subnets[local.functionapp_subnet_name], module.synapse_network_failover.vnet_subnets[local.compute_subnet_name]])
   shares = [
@@ -83,6 +100,11 @@ module "storage_account_failover" {
       quota = 5120
     }
   ]
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 # Commenting out because the current configuration is broken, and we may need
@@ -128,7 +150,6 @@ module "function_app" {
   storage_account_access_key   = module.storage_account[each.key].primary_access_key
   environment                  = var.environment
   location                     = module.azure_region.location_cli
-  tags                         = local.tags
   application_insights_key     = azurerm_application_insights.function_app_insights[each.key].instrumentation_key
   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
   app_settings                 = try(each.value.app_settings, null)
@@ -140,6 +161,11 @@ module "function_app" {
   servicebus_namespace_odw     = module.synapse_ingestion.service_bus_namespace_name
   message_storage_account      = var.message_storage_account
   message_storage_container    = var.message_storage_container
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "function_app_failover" {
@@ -157,7 +183,6 @@ module "function_app_failover" {
   storage_account_access_key = module.storage_account_failover[each.key].primary_access_key
   environment                = var.environment
   location                   = module.azure_region.paired_location.location_cli
-  tags                       = local.tags
   application_insights_key   = azurerm_application_insights.function_app_insights[each.key].instrumentation_key
   synapse_vnet_subnet_names  = module.synapse_network_failover.vnet_subnets
   app_settings               = try(each.value.app_settings, null)
@@ -165,6 +190,11 @@ module "function_app_failover" {
   file_share_name            = "pins-${each.key}-${local.resource_suffix_failover}"
   servicebus_namespace       = var.odt_back_office_service_bus_name
   servicebus_namespace_odw   = var.service_bus_failover_enabled ? module.synapse_ingestion_failover[0].service_bus_namespace_name : module.synapse_ingestion.service_bus_namespace_name
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 # module "function_app_openlineage_receiver" {
@@ -259,5 +289,10 @@ resource "azurerm_application_insights" "function_app_insights" {
   retention_in_days   = 30
   workspace_id        = module.synapse_monitoring.log_analytics_workspace_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod" ? {
+      resourceType = "application insights"
+    } : {}
+  )
 }

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -4,10 +4,7 @@ resource "azurerm_resource_group" "function_app" {
   name     = "pins-rg-function-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "function_app_failover" {
@@ -16,10 +13,7 @@ resource "azurerm_resource_group" "function_app_failover" {
   name     = "pins-rg-function-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "service_plan" {
@@ -32,10 +26,7 @@ module "service_plan" {
   environment         = var.environment
   location            = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "service_plan_failover" {
@@ -48,10 +39,7 @@ module "service_plan_failover" {
   environment         = var.environment
   location            = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "storage_account" {
@@ -74,10 +62,7 @@ module "storage_account" {
     }
   ]
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 
@@ -101,10 +86,7 @@ module "storage_account_failover" {
     }
   ]
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 # Commenting out because the current configuration is broken, and we may need
@@ -162,10 +144,7 @@ module "function_app" {
   message_storage_account      = var.message_storage_account
   message_storage_container    = var.message_storage_container
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "function_app_failover" {
@@ -191,10 +170,7 @@ module "function_app_failover" {
   servicebus_namespace       = var.odt_back_office_service_bus_name
   servicebus_namespace_odw   = var.service_bus_failover_enabled ? module.synapse_ingestion_failover[0].service_bus_namespace_name : module.synapse_ingestion.service_bus_namespace_name
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 # module "function_app_openlineage_receiver" {

--- a/infrastructure/workload-ingestion.tf
+++ b/infrastructure/workload-ingestion.tf
@@ -2,20 +2,14 @@ resource "azurerm_resource_group" "ingestion" {
   name     = "pins-rg-ingestion-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "ingestion_failover" {
   name     = "pins-rg-ingestion-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_ingestion" {
@@ -37,10 +31,7 @@ module "synapse_ingestion" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_ingestion_failover" {
@@ -64,8 +55,5 @@ module "synapse_ingestion_failover" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }

--- a/infrastructure/workload-ingestion.tf
+++ b/infrastructure/workload-ingestion.tf
@@ -2,14 +2,14 @@ resource "azurerm_resource_group" "ingestion" {
   name     = "pins-rg-ingestion-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "ingestion_failover" {
   name     = "pins-rg-ingestion-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_ingestion" {
@@ -31,7 +31,7 @@ module "synapse_ingestion" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_ingestion_failover" {
@@ -55,5 +55,5 @@ module "synapse_ingestion_failover" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-ingestion.tf
+++ b/infrastructure/workload-ingestion.tf
@@ -2,14 +2,14 @@ resource "azurerm_resource_group" "ingestion" {
   name     = "pins-rg-ingestion-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "ingestion_failover" {
   name     = "pins-rg-ingestion-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_ingestion" {
@@ -31,7 +31,7 @@ module "synapse_ingestion" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_ingestion_failover" {
@@ -55,5 +55,5 @@ module "synapse_ingestion_failover" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-ingestion.tf
+++ b/infrastructure/workload-ingestion.tf
@@ -2,14 +2,14 @@ resource "azurerm_resource_group" "ingestion" {
   name     = "pins-rg-ingestion-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "ingestion_failover" {
   name     = "pins-rg-ingestion-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_ingestion" {
@@ -31,7 +31,7 @@ module "synapse_ingestion" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_ingestion_failover" {
@@ -55,5 +55,5 @@ module "synapse_ingestion_failover" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-ingestion.tf
+++ b/infrastructure/workload-ingestion.tf
@@ -2,14 +2,20 @@ resource "azurerm_resource_group" "ingestion" {
   name     = "pins-rg-ingestion-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "ingestion_failover" {
   name     = "pins-rg-ingestion-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_ingestion" {
@@ -31,7 +37,10 @@ module "synapse_ingestion" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_ingestion_failover" {
@@ -55,5 +64,8 @@ module "synapse_ingestion_failover" {
   synapse_private_endpoint_subnet_name    = local.synapse_subnet_name
   odw_servicebus_dns_zone_id              = data.azurerm_private_dns_zone.tooling_servicebus.id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }

--- a/infrastructure/workload-logic-app.tf
+++ b/infrastructure/workload-logic-app.tf
@@ -6,7 +6,7 @@ resource "azurerm_api_connection" "azure_blob" {
   name                = var.az_api_blob_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 import {
@@ -21,7 +21,7 @@ resource "azurerm_api_connection" "office_365" {
   name                = var.az_api_office365_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 import {
@@ -155,7 +155,7 @@ module "specialist_case_validation_check" {
     }
   ]
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 import {

--- a/infrastructure/workload-logic-app.tf
+++ b/infrastructure/workload-logic-app.tf
@@ -6,7 +6,7 @@ resource "azurerm_api_connection" "azure_blob" {
   name                = var.az_api_blob_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 import {
@@ -21,7 +21,7 @@ resource "azurerm_api_connection" "office_365" {
   name                = var.az_api_office365_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 import {
@@ -155,7 +155,7 @@ module "specialist_case_validation_check" {
     }
   ]
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 import {

--- a/infrastructure/workload-logic-app.tf
+++ b/infrastructure/workload-logic-app.tf
@@ -5,7 +5,11 @@ resource "azurerm_api_connection" "azure_blob" {
   managed_api_id      = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/providers/Microsoft.Web/locations/uksouth/managedApis/azureblob"
   name                = var.az_api_blob_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
-  tags                = local.tags
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 import {
@@ -19,7 +23,11 @@ resource "azurerm_api_connection" "office_365" {
   managed_api_id      = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/providers/Microsoft.Web/locations/uksouth/managedApis/office365"
   name                = var.az_api_office365_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
-  tags                = local.tags
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 import {
@@ -152,7 +160,11 @@ module "specialist_case_validation_check" {
       })
     }
   ]
-  tags = local.tags
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 import {

--- a/infrastructure/workload-logic-app.tf
+++ b/infrastructure/workload-logic-app.tf
@@ -6,10 +6,7 @@ resource "azurerm_api_connection" "azure_blob" {
   name                = var.az_api_blob_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 import {
@@ -24,10 +21,7 @@ resource "azurerm_api_connection" "office_365" {
   name                = var.az_api_office365_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 import {
@@ -161,10 +155,7 @@ module "specialist_case_validation_check" {
     }
   ]
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 import {

--- a/infrastructure/workload-logic-app.tf
+++ b/infrastructure/workload-logic-app.tf
@@ -6,7 +6,7 @@ resource "azurerm_api_connection" "azure_blob" {
   name                = var.az_api_blob_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 import {
@@ -21,7 +21,7 @@ resource "azurerm_api_connection" "office_365" {
   name                = var.az_api_office365_connection_names[var.environment]
   resource_group_name = azurerm_resource_group.data.name
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 import {
@@ -155,7 +155,7 @@ module "specialist_case_validation_check" {
     }
   ]
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 import {

--- a/infrastructure/workload-management.tf
+++ b/infrastructure/workload-management.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "data_management" {
   name     = "pins-rg-datamgmt-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "data_management_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "data_management_failover" {
   name     = "pins-rg-datamgmt-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_management" {
@@ -34,7 +34,7 @@ module "synapse_management" {
   vnet_subnet_ids_failover               = module.synapse_network_failover.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 
@@ -83,7 +83,7 @@ module "synapse_management_failover" {
   vnet_subnet_ids_failover               = module.synapse_network.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "bastion_host" {
@@ -106,7 +106,7 @@ module "bastion_host" {
   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "bastion_host_failover" {
@@ -129,5 +129,5 @@ module "bastion_host_failover" {
   synapse_vnet_subnet_names    = module.synapse_network_failover.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-management.tf
+++ b/infrastructure/workload-management.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "data_management" {
   name     = "pins-rg-datamgmt-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "data_management_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "data_management_failover" {
   name     = "pins-rg-datamgmt-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_management" {
@@ -34,7 +34,7 @@ module "synapse_management" {
   vnet_subnet_ids_failover               = module.synapse_network_failover.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 
@@ -83,7 +83,7 @@ module "synapse_management_failover" {
   vnet_subnet_ids_failover               = module.synapse_network.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "bastion_host" {
@@ -106,7 +106,7 @@ module "bastion_host" {
   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "bastion_host_failover" {
@@ -129,5 +129,5 @@ module "bastion_host_failover" {
   synapse_vnet_subnet_names    = module.synapse_network_failover.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-management.tf
+++ b/infrastructure/workload-management.tf
@@ -2,7 +2,10 @@ resource "azurerm_resource_group" "data_management" {
   name     = "pins-rg-datamgmt-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "data_management_failover" {
@@ -11,7 +14,10 @@ resource "azurerm_resource_group" "data_management_failover" {
   name     = "pins-rg-datamgmt-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_management" {
@@ -34,7 +40,10 @@ module "synapse_management" {
   vnet_subnet_ids_failover               = module.synapse_network_failover.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 
@@ -83,7 +92,10 @@ module "synapse_management_failover" {
   vnet_subnet_ids_failover               = module.synapse_network.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "bastion_host" {
@@ -106,7 +118,10 @@ module "bastion_host" {
   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "bastion_host_failover" {
@@ -129,5 +144,8 @@ module "bastion_host_failover" {
   synapse_vnet_subnet_names    = module.synapse_network_failover.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }

--- a/infrastructure/workload-management.tf
+++ b/infrastructure/workload-management.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "data_management" {
   name     = "pins-rg-datamgmt-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "data_management_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "data_management_failover" {
   name     = "pins-rg-datamgmt-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_management" {
@@ -34,7 +34,7 @@ module "synapse_management" {
   vnet_subnet_ids_failover               = module.synapse_network_failover.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 
@@ -83,7 +83,7 @@ module "synapse_management_failover" {
   vnet_subnet_ids_failover               = module.synapse_network.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "bastion_host" {
@@ -106,7 +106,7 @@ module "bastion_host" {
   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "bastion_host_failover" {
@@ -129,5 +129,5 @@ module "bastion_host_failover" {
   synapse_vnet_subnet_names    = module.synapse_network_failover.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-management.tf
+++ b/infrastructure/workload-management.tf
@@ -2,10 +2,7 @@ resource "azurerm_resource_group" "data_management" {
   name     = "pins-rg-datamgmt-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "data_management_failover" {
@@ -14,10 +11,7 @@ resource "azurerm_resource_group" "data_management_failover" {
   name     = "pins-rg-datamgmt-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_management" {
@@ -40,10 +34,7 @@ module "synapse_management" {
   vnet_subnet_ids_failover               = module.synapse_network_failover.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 
@@ -92,10 +83,7 @@ module "synapse_management_failover" {
   vnet_subnet_ids_failover               = module.synapse_network.vnet_subnets
   purview_msi_id                         = var.purview_msi_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "bastion_host" {
@@ -118,10 +106,7 @@ module "bastion_host" {
   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "bastion_host_failover" {
@@ -144,8 +129,5 @@ module "bastion_host_failover" {
   synapse_vnet_subnet_names    = module.synapse_network_failover.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }

--- a/infrastructure/workload-monitoring.tf
+++ b/infrastructure/workload-monitoring.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "monitoring" {
   name     = "pins-rg-monitoring-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "monitoring_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "monitoring_failover" {
   name     = "pins-rg-monitoring-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_monitoring" {
@@ -38,7 +38,7 @@ module "synapse_monitoring" {
   synapse_workspace_id                     = module.synapse_workspace_private.synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network.vnet_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_monitoring_failover" {
@@ -67,5 +67,5 @@ module "synapse_monitoring_failover" {
   synapse_workspace_id                     = module.synapse_workspace_private_failover[0].synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network_failover.vnet_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-monitoring.tf
+++ b/infrastructure/workload-monitoring.tf
@@ -2,10 +2,7 @@ resource "azurerm_resource_group" "monitoring" {
   name     = "pins-rg-monitoring-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "monitoring_failover" {
@@ -14,10 +11,7 @@ resource "azurerm_resource_group" "monitoring_failover" {
   name     = "pins-rg-monitoring-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_monitoring" {
@@ -44,10 +38,7 @@ module "synapse_monitoring" {
   synapse_workspace_id                     = module.synapse_workspace_private.synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network.vnet_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_monitoring_failover" {
@@ -76,8 +67,5 @@ module "synapse_monitoring_failover" {
   synapse_workspace_id                     = module.synapse_workspace_private_failover[0].synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network_failover.vnet_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }

--- a/infrastructure/workload-monitoring.tf
+++ b/infrastructure/workload-monitoring.tf
@@ -2,7 +2,10 @@ resource "azurerm_resource_group" "monitoring" {
   name     = "pins-rg-monitoring-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "monitoring_failover" {
@@ -11,7 +14,10 @@ resource "azurerm_resource_group" "monitoring_failover" {
   name     = "pins-rg-monitoring-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_monitoring" {
@@ -38,7 +44,10 @@ module "synapse_monitoring" {
   synapse_workspace_id                     = module.synapse_workspace_private.synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network.vnet_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_monitoring_failover" {
@@ -67,5 +76,8 @@ module "synapse_monitoring_failover" {
   synapse_workspace_id                     = module.synapse_workspace_private_failover[0].synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network_failover.vnet_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }

--- a/infrastructure/workload-monitoring.tf
+++ b/infrastructure/workload-monitoring.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "monitoring" {
   name     = "pins-rg-monitoring-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "monitoring_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "monitoring_failover" {
   name     = "pins-rg-monitoring-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_monitoring" {
@@ -38,7 +38,7 @@ module "synapse_monitoring" {
   synapse_workspace_id                     = module.synapse_workspace_private.synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network.vnet_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_monitoring_failover" {
@@ -67,5 +67,5 @@ module "synapse_monitoring_failover" {
   synapse_workspace_id                     = module.synapse_workspace_private_failover[0].synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network_failover.vnet_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-monitoring.tf
+++ b/infrastructure/workload-monitoring.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "monitoring" {
   name     = "pins-rg-monitoring-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "monitoring_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "monitoring_failover" {
   name     = "pins-rg-monitoring-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_monitoring" {
@@ -38,7 +38,7 @@ module "synapse_monitoring" {
   synapse_workspace_id                     = module.synapse_workspace_private.synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network.vnet_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_monitoring_failover" {
@@ -67,5 +67,5 @@ module "synapse_monitoring_failover" {
   synapse_workspace_id                     = module.synapse_workspace_private_failover[0].synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network_failover.vnet_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-mpesc.tf
+++ b/infrastructure/workload-mpesc.tf
@@ -12,7 +12,7 @@ module "storage_account_horizon_migration" {
   container_name                          = var.horizon_migration.container_name
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 

--- a/infrastructure/workload-mpesc.tf
+++ b/infrastructure/workload-mpesc.tf
@@ -12,5 +12,5 @@ module "storage_account_horizon_migration" {
   container_name                          = var.horizon_migration.container_name
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-mpesc.tf
+++ b/infrastructure/workload-mpesc.tf
@@ -9,9 +9,13 @@ module "storage_account_horizon_migration" {
   service_name                            = var.horizon_migration.service_name
   environment                             = var.environment
   location                                = module.azure_region.location_cli
-  tags                                    = local.tags
   container_name                          = var.horizon_migration.container_name
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
+
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 

--- a/infrastructure/workload-mpesc.tf
+++ b/infrastructure/workload-mpesc.tf
@@ -12,7 +12,5 @@ module "storage_account_horizon_migration" {
   container_name                          = var.horizon_migration.container_name
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
-
-

--- a/infrastructure/workload-mpesc.tf
+++ b/infrastructure/workload-mpesc.tf
@@ -12,10 +12,7 @@ module "storage_account_horizon_migration" {
   container_name                          = var.horizon_migration.container_name
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 

--- a/infrastructure/workload-network.tf
+++ b/infrastructure/workload-network.tf
@@ -2,21 +2,30 @@ resource "azurerm_resource_group" "network" {
   name     = "pins-rg-network-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "network_failover" {
   name     = "pins-rg-network-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "network_global" {
   name     = "pins-rg-network-${local.resource_suffix_global}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_network" {
@@ -32,7 +41,10 @@ module "synapse_network" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block
   vnet_subnets            = var.vnet_subnets
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_network_failover" {
@@ -48,14 +60,20 @@ module "synapse_network_failover" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block_failover
   vnet_subnets            = var.vnet_subnets
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone" "synapse" {
   name                = "privatelink.azuresynapse.net"
   resource_group_name = azurerm_resource_group.network_global.name
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
@@ -65,7 +83,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
@@ -85,7 +106,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover" {
@@ -105,7 +129,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
@@ -115,7 +142,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
@@ -124,7 +154,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network.vnet_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
@@ -133,7 +166,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network_failover.vnet_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
@@ -183,7 +219,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_virtual_network_peering" "pri_sec" {

--- a/infrastructure/workload-network.tf
+++ b/infrastructure/workload-network.tf
@@ -2,30 +2,21 @@ resource "azurerm_resource_group" "network" {
   name     = "pins-rg-network-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "network_failover" {
   name     = "pins-rg-network-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "network_global" {
   name     = "pins-rg-network-${local.resource_suffix_global}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_network" {
@@ -41,10 +32,7 @@ module "synapse_network" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block
   vnet_subnets            = var.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_network_failover" {
@@ -60,20 +48,14 @@ module "synapse_network_failover" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block_failover
   vnet_subnets            = var.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone" "synapse" {
   name                = "privatelink.azuresynapse.net"
   resource_group_name = azurerm_resource_group.network_global.name
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
@@ -83,10 +65,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
@@ -106,10 +85,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover" {
@@ -129,10 +105,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
@@ -142,10 +115,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
@@ -154,10 +124,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network.vnet_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
@@ -166,10 +133,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network_failover.vnet_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
@@ -219,10 +183,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_virtual_network_peering" "pri_sec" {

--- a/infrastructure/workload-network.tf
+++ b/infrastructure/workload-network.tf
@@ -2,21 +2,21 @@ resource "azurerm_resource_group" "network" {
   name     = "pins-rg-network-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "network_failover" {
   name     = "pins-rg-network-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "network_global" {
   name     = "pins-rg-network-${local.resource_suffix_global}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_network" {
@@ -32,7 +32,7 @@ module "synapse_network" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block
   vnet_subnets            = var.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_network_failover" {
@@ -48,14 +48,14 @@ module "synapse_network_failover" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block_failover
   vnet_subnets            = var.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone" "synapse" {
   name                = "privatelink.azuresynapse.net"
   resource_group_name = azurerm_resource_group.network_global.name
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
@@ -65,7 +65,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
@@ -75,7 +75,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
@@ -85,7 +85,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover" {
@@ -95,7 +95,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover"
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
@@ -105,7 +105,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
@@ -115,7 +115,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
@@ -124,7 +124,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network.vnet_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
@@ -133,7 +133,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network_failover.vnet_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
@@ -143,7 +143,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev_failover" {
@@ -153,7 +153,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev_fa
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql" {
@@ -163,7 +163,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql_failover" {
@@ -173,7 +173,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql_fa
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
@@ -183,7 +183,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_virtual_network_peering" "pri_sec" {

--- a/infrastructure/workload-network.tf
+++ b/infrastructure/workload-network.tf
@@ -2,21 +2,21 @@ resource "azurerm_resource_group" "network" {
   name     = "pins-rg-network-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "network_failover" {
   name     = "pins-rg-network-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "network_global" {
   name     = "pins-rg-network-${local.resource_suffix_global}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_network" {
@@ -32,7 +32,7 @@ module "synapse_network" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block
   vnet_subnets            = var.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_network_failover" {
@@ -48,14 +48,14 @@ module "synapse_network_failover" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block_failover
   vnet_subnets            = var.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone" "synapse" {
   name                = "privatelink.azuresynapse.net"
   resource_group_name = azurerm_resource_group.network_global.name
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
@@ -65,7 +65,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
@@ -75,7 +75,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
@@ -85,7 +85,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover" {
@@ -95,7 +95,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover"
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
@@ -105,7 +105,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
@@ -115,7 +115,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
@@ -124,7 +124,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network.vnet_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
@@ -133,7 +133,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network_failover.vnet_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
@@ -143,7 +143,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev_failover" {
@@ -153,7 +153,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev_fa
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql" {
@@ -163,7 +163,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql_failover" {
@@ -173,7 +173,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql_fa
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
@@ -183,7 +183,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_virtual_network_peering" "pri_sec" {

--- a/infrastructure/workload-network.tf
+++ b/infrastructure/workload-network.tf
@@ -2,21 +2,21 @@ resource "azurerm_resource_group" "network" {
   name     = "pins-rg-network-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "network_failover" {
   name     = "pins-rg-network-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "network_global" {
   name     = "pins-rg-network-${local.resource_suffix_global}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_network" {
@@ -32,7 +32,7 @@ module "synapse_network" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block
   vnet_subnets            = var.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_network_failover" {
@@ -48,14 +48,14 @@ module "synapse_network_failover" {
   vnet_base_cidr_block    = var.vnet_base_cidr_block_failover
   vnet_subnets            = var.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone" "synapse" {
   name                = "privatelink.azuresynapse.net"
   resource_group_name = azurerm_resource_group.network_global.name
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
@@ -65,7 +65,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
@@ -75,7 +75,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
@@ -85,7 +85,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "datalake_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover" {
@@ -95,7 +95,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob_failover"
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
@@ -105,7 +105,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
@@ -115,7 +115,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_failover" {
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
@@ -124,7 +124,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network.vnet_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
@@ -133,7 +133,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "synapse_failover" {
   private_dns_zone_name = azurerm_private_dns_zone.synapse.name
   virtual_network_id    = module.synapse_network_failover.vnet_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
@@ -143,7 +143,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev_failover" {
@@ -153,7 +153,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_dev_fa
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql" {
@@ -163,7 +163,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql_failover" {
@@ -173,7 +173,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "tooling_synapse_sql_fa
   virtual_network_id    = module.synapse_network_failover.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
@@ -183,7 +183,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "servicebus" {
   virtual_network_id    = module.synapse_network.vnet_id
   provider              = azurerm.tooling
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_virtual_network_peering" "pri_sec" {
@@ -337,4 +337,3 @@ data "azurerm_private_dns_zone" "tooling_servicebus" {
   resource_group_name = var.tooling_config.network_rg
   provider            = azurerm.tooling
 }
-

--- a/infrastructure/workload-odt-backoffice-sb.tf
+++ b/infrastructure/workload-odt-backoffice-sb.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "odt_backoffice_sb" {
@@ -29,7 +29,7 @@ module "odt_backoffice_sb" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,
@@ -50,7 +50,7 @@ module "odt_backoffice_sb_failover" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,
@@ -74,7 +74,7 @@ module "odt_appeals_back_office_sb" {
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
   topics_to_send                          = ["listed-building"]
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-odt-backoffice-sb.tf
+++ b/infrastructure/workload-odt-backoffice-sb.tf
@@ -4,10 +4,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
@@ -16,10 +13,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "odt_backoffice_sb" {
@@ -35,10 +29,7 @@ module "odt_backoffice_sb" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 
   providers = {
     azurerm     = azurerm,
@@ -59,10 +50,7 @@ module "odt_backoffice_sb_failover" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 
   providers = {
     azurerm     = azurerm,
@@ -86,10 +74,7 @@ module "odt_appeals_back_office_sb" {
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
   topics_to_send                          = ["listed-building"]
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-odt-backoffice-sb.tf
+++ b/infrastructure/workload-odt-backoffice-sb.tf
@@ -4,7 +4,10 @@ resource "azurerm_resource_group" "odt_backoffice_sb" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
@@ -13,7 +16,10 @@ resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "odt_backoffice_sb" {
@@ -29,7 +35,10 @@ module "odt_backoffice_sb" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 
   providers = {
     azurerm     = azurerm,
@@ -50,7 +59,10 @@ module "odt_backoffice_sb_failover" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 
   providers = {
     azurerm     = azurerm,
@@ -74,7 +86,10 @@ module "odt_appeals_back_office_sb" {
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
   topics_to_send                          = ["listed-building"]
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-odt-backoffice-sb.tf
+++ b/infrastructure/workload-odt-backoffice-sb.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "odt_backoffice_sb" {
@@ -29,7 +29,7 @@ module "odt_backoffice_sb" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 
   providers = {
     azurerm     = azurerm,
@@ -50,7 +50,7 @@ module "odt_backoffice_sb_failover" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 
   providers = {
     azurerm     = azurerm,
@@ -74,7 +74,7 @@ module "odt_appeals_back_office_sb" {
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
   topics_to_send                          = ["listed-building"]
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-odt-backoffice-sb.tf
+++ b/infrastructure/workload-odt-backoffice-sb.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "odt_backoffice_sb_failover" {
   name     = "pins-rg-odt-bo-sb-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "odt_backoffice_sb" {
@@ -29,7 +29,7 @@ module "odt_backoffice_sb" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,
@@ -50,7 +50,7 @@ module "odt_backoffice_sb_failover" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,
@@ -74,7 +74,7 @@ module "odt_appeals_back_office_sb" {
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
   topics_to_send                          = ["listed-building"]
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-s62a.tf
+++ b/infrastructure/workload-s62a.tf
@@ -34,5 +34,5 @@ resource "azurerm_private_endpoint" "s62a_endpoint" {
     is_manual_connection           = false
   }
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-s62a.tf
+++ b/infrastructure/workload-s62a.tf
@@ -33,5 +33,6 @@ resource "azurerm_private_endpoint" "s62a_endpoint" {
     subresource_names              = ["blob"]
     is_manual_connection           = false
   }
+  
   tags = local.tags
 }

--- a/infrastructure/workload-s62a.tf
+++ b/infrastructure/workload-s62a.tf
@@ -34,5 +34,5 @@ resource "azurerm_private_endpoint" "s62a_endpoint" {
     is_manual_connection           = false
   }
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = local.tags
 }

--- a/infrastructure/workload-s62a.tf
+++ b/infrastructure/workload-s62a.tf
@@ -33,6 +33,5 @@ resource "azurerm_private_endpoint" "s62a_endpoint" {
     subresource_names              = ["blob"]
     is_manual_connection           = false
   }
-
   tags = local.tags
 }

--- a/infrastructure/workload-s62a.tf
+++ b/infrastructure/workload-s62a.tf
@@ -34,5 +34,5 @@ resource "azurerm_private_endpoint" "s62a_endpoint" {
     is_manual_connection           = false
   }
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-s62a.tf
+++ b/infrastructure/workload-s62a.tf
@@ -34,5 +34,5 @@ resource "azurerm_private_endpoint" "s62a_endpoint" {
     is_manual_connection           = false
   }
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-shir.tf
+++ b/infrastructure/workload-shir.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "shir" {
   name     = "pins-rg-shir-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "shir_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "shir_failover" {
   name     = "pins-rg-shir-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_shir" {
@@ -27,7 +27,7 @@ module "synapse_shir" {
   synapse_workspace_id     = module.synapse_workspace_private.synapse_workspace_id
   vnet_subnet_ids          = module.synapse_network.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_shir_failover" {
@@ -45,5 +45,5 @@ module "synapse_shir_failover" {
   run_shir_setup_script    = var.run_shir_setup_script
   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-shir.tf
+++ b/infrastructure/workload-shir.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "shir" {
   name     = "pins-rg-shir-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "shir_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "shir_failover" {
   name     = "pins-rg-shir-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_shir" {
@@ -27,7 +27,7 @@ module "synapse_shir" {
   synapse_workspace_id     = module.synapse_workspace_private.synapse_workspace_id
   vnet_subnet_ids          = module.synapse_network.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_shir_failover" {
@@ -45,5 +45,5 @@ module "synapse_shir_failover" {
   run_shir_setup_script    = var.run_shir_setup_script
   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-shir.tf
+++ b/infrastructure/workload-shir.tf
@@ -2,10 +2,7 @@ resource "azurerm_resource_group" "shir" {
   name     = "pins-rg-shir-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "shir_failover" {
@@ -14,10 +11,7 @@ resource "azurerm_resource_group" "shir_failover" {
   name     = "pins-rg-shir-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_shir" {
@@ -33,10 +27,7 @@ module "synapse_shir" {
   synapse_workspace_id     = module.synapse_workspace_private.synapse_workspace_id
   vnet_subnet_ids          = module.synapse_network.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_shir_failover" {
@@ -54,8 +45,5 @@ module "synapse_shir_failover" {
   run_shir_setup_script    = var.run_shir_setup_script
   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }

--- a/infrastructure/workload-shir.tf
+++ b/infrastructure/workload-shir.tf
@@ -2,7 +2,10 @@ resource "azurerm_resource_group" "shir" {
   name     = "pins-rg-shir-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "shir_failover" {
@@ -11,7 +14,10 @@ resource "azurerm_resource_group" "shir_failover" {
   name     = "pins-rg-shir-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_shir" {
@@ -23,12 +29,14 @@ module "synapse_shir" {
   service_name        = local.service_name
 
   devops_agent_subnet_name = local.compute_subnet_name
+  run_shir_setup_script    = var.run_shir_setup_script
   synapse_workspace_id     = module.synapse_workspace_private.synapse_workspace_id
   vnet_subnet_ids          = module.synapse_network.vnet_subnets
 
-  tags = local.tags
-
-  run_shir_setup_script = var.run_shir_setup_script
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_shir_failover" {
@@ -43,9 +51,11 @@ module "synapse_shir_failover" {
 
   devops_agent_subnet_name = local.compute_subnet_name
   synapse_workspace_id     = module.synapse_workspace_private_failover[0].synapse_workspace_id
+  run_shir_setup_script    = var.run_shir_setup_script
   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 
-  tags = local.tags
-
-  run_shir_setup_script = var.run_shir_setup_script
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }

--- a/infrastructure/workload-shir.tf
+++ b/infrastructure/workload-shir.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "shir" {
   name     = "pins-rg-shir-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "shir_failover" {
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "shir_failover" {
   name     = "pins-rg-shir-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_shir" {
@@ -27,7 +27,7 @@ module "synapse_shir" {
   synapse_workspace_id     = module.synapse_workspace_private.synapse_workspace_id
   vnet_subnet_ids          = module.synapse_network.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_shir_failover" {
@@ -45,5 +45,5 @@ module "synapse_shir_failover" {
   run_shir_setup_script    = var.run_shir_setup_script
   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-sql-server.tf
+++ b/infrastructure/workload-sql-server.tf
@@ -4,7 +4,10 @@ resource "azurerm_resource_group" "sql_server" {
   name     = "pins-rg-sqlserver-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "sql_server_failover" {
@@ -13,7 +16,10 @@ resource "azurerm_resource_group" "sql_server_failover" {
   name     = "pins-rg-sqlserver-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_sql_server" {
@@ -35,7 +41,10 @@ module "synapse_sql_server" {
   vnet_subnet_ids                   = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network_failover.vnet_subnets
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "synapse_sql_server_failover" {
@@ -57,5 +66,8 @@ module "synapse_sql_server_failover" {
   vnet_subnet_ids                   = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network.vnet_subnets
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }

--- a/infrastructure/workload-sql-server.tf
+++ b/infrastructure/workload-sql-server.tf
@@ -4,10 +4,7 @@ resource "azurerm_resource_group" "sql_server" {
   name     = "pins-rg-sqlserver-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "sql_server_failover" {
@@ -16,10 +13,7 @@ resource "azurerm_resource_group" "sql_server_failover" {
   name     = "pins-rg-sqlserver-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_sql_server" {
@@ -41,10 +35,7 @@ module "synapse_sql_server" {
   vnet_subnet_ids                   = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "synapse_sql_server_failover" {
@@ -66,8 +57,5 @@ module "synapse_sql_server_failover" {
   vnet_subnet_ids                   = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network.vnet_subnets
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }

--- a/infrastructure/workload-sql-server.tf
+++ b/infrastructure/workload-sql-server.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "sql_server" {
   name     = "pins-rg-sqlserver-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "sql_server_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "sql_server_failover" {
   name     = "pins-rg-sqlserver-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_sql_server" {
@@ -35,7 +35,7 @@ module "synapse_sql_server" {
   vnet_subnet_ids                   = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network_failover.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_sql_server_failover" {
@@ -57,5 +57,5 @@ module "synapse_sql_server_failover" {
   vnet_subnet_ids                   = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network.vnet_subnets
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-sql-server.tf
+++ b/infrastructure/workload-sql-server.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "sql_server" {
   name     = "pins-rg-sqlserver-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "sql_server_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "sql_server_failover" {
   name     = "pins-rg-sqlserver-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_sql_server" {
@@ -35,7 +35,7 @@ module "synapse_sql_server" {
   vnet_subnet_ids                   = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "synapse_sql_server_failover" {
@@ -57,5 +57,5 @@ module "synapse_sql_server_failover" {
   vnet_subnet_ids                   = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network.vnet_subnets
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-sql-server.tf
+++ b/infrastructure/workload-sql-server.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "sql_server" {
   name     = "pins-rg-sqlserver-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "sql_server_failover" {
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "sql_server_failover" {
   name     = "pins-rg-sqlserver-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_sql_server" {
@@ -35,7 +35,7 @@ module "synapse_sql_server" {
   vnet_subnet_ids                   = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network_failover.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "synapse_sql_server_failover" {
@@ -57,5 +57,5 @@ module "synapse_sql_server_failover" {
   vnet_subnet_ids                   = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network.vnet_subnets
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -59,7 +59,7 @@ module "synapse_workspace_private" {
   purview_event_hub_fqdn = var.link_purview_account ? var.purview_event_hub_fqdn : null
   odw_service_bus_fqdn   = "${module.synapse_ingestion.service_bus_namespace_name}.servicebus.windows.net"
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
   providers = {
     azurerm     = azurerm,
     azurerm.odt = azurerm.odt
@@ -125,7 +125,7 @@ module "synapse_workspace_private_failover" {
   purview_event_hub_fqdn = null
   odw_service_bus_fqdn   = null
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -59,7 +59,7 @@ module "synapse_workspace_private" {
   purview_event_hub_fqdn = var.link_purview_account ? var.purview_event_hub_fqdn : null
   odw_service_bus_fqdn   = "${module.synapse_ingestion.service_bus_namespace_name}.servicebus.windows.net"
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
   providers = {
     azurerm     = azurerm,
     azurerm.odt = azurerm.odt
@@ -125,7 +125,7 @@ module "synapse_workspace_private_failover" {
   purview_event_hub_fqdn = null
   odw_service_bus_fqdn   = null
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -59,7 +59,7 @@ module "synapse_workspace_private" {
   purview_event_hub_fqdn = var.link_purview_account ? var.purview_event_hub_fqdn : null
   odw_service_bus_fqdn   = "${module.synapse_ingestion.service_bus_namespace_name}.servicebus.windows.net"
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
   providers = {
     azurerm     = azurerm,
     azurerm.odt = azurerm.odt
@@ -125,7 +125,7 @@ module "synapse_workspace_private_failover" {
   purview_event_hub_fqdn = null
   odw_service_bus_fqdn   = null
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -59,10 +59,7 @@ module "synapse_workspace_private" {
   purview_event_hub_fqdn = var.link_purview_account ? var.purview_event_hub_fqdn : null
   odw_service_bus_fqdn   = "${module.synapse_ingestion.service_bus_namespace_name}.servicebus.windows.net"
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
   providers = {
     azurerm     = azurerm,
     azurerm.odt = azurerm.odt
@@ -128,10 +125,7 @@ module "synapse_workspace_private_failover" {
   purview_event_hub_fqdn = null
   odw_service_bus_fqdn   = null
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -59,8 +59,10 @@ module "synapse_workspace_private" {
   purview_event_hub_fqdn = var.link_purview_account ? var.purview_event_hub_fqdn : null
   odw_service_bus_fqdn   = "${module.synapse_ingestion.service_bus_namespace_name}.servicebus.windows.net"
 
-  tags = local.tags
-
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
   providers = {
     azurerm     = azurerm,
     azurerm.odt = azurerm.odt
@@ -126,7 +128,10 @@ module "synapse_workspace_private_failover" {
   purview_event_hub_fqdn = null
   odw_service_bus_fqdn   = null
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 
   providers = {
     azurerm     = azurerm,

--- a/infrastructure/workload-zendesk.tf
+++ b/infrastructure/workload-zendesk.tf
@@ -7,10 +7,7 @@ resource "azurerm_resource_group" "zendesk" {
   name     = "pins-rg-logic-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 resource "azurerm_resource_group" "zendesk_failover" {
@@ -19,10 +16,7 @@ resource "azurerm_resource_group" "zendesk_failover" {
   name     = "pins-rg-logic-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "zendesk" {
@@ -39,10 +33,7 @@ module "zendesk" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion.service_bus_primary_connection_string
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }
 
 module "zendesk_failover" {
@@ -59,8 +50,5 @@ module "zendesk_failover" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion_failover[0].service_bus_primary_connection_string
 
-  tags = merge(
-    local.tags,
-    var.environment == "prod"
-  )
+  tags = local.tags
 }

--- a/infrastructure/workload-zendesk.tf
+++ b/infrastructure/workload-zendesk.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "zendesk" {
   name     = "pins-rg-logic-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "zendesk_failover" {
@@ -16,7 +16,7 @@ resource "azurerm_resource_group" "zendesk_failover" {
   name     = "pins-rg-logic-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "zendesk" {
@@ -33,7 +33,7 @@ module "zendesk" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion.service_bus_primary_connection_string
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "zendesk_failover" {
@@ -50,5 +50,5 @@ module "zendesk_failover" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion_failover[0].service_bus_primary_connection_string
 
-  tags = merge(local.tags, var.environment == "prod")
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/infrastructure/workload-zendesk.tf
+++ b/infrastructure/workload-zendesk.tf
@@ -7,7 +7,10 @@ resource "azurerm_resource_group" "zendesk" {
   name     = "pins-rg-logic-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 resource "azurerm_resource_group" "zendesk_failover" {
@@ -16,7 +19,10 @@ resource "azurerm_resource_group" "zendesk_failover" {
   name     = "pins-rg-logic-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "zendesk" {
@@ -33,7 +39,10 @@ module "zendesk" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion.service_bus_primary_connection_string
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }
 
 module "zendesk_failover" {
@@ -50,5 +59,8 @@ module "zendesk_failover" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion_failover[0].service_bus_primary_connection_string
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    var.environment == "prod"
+  )
 }

--- a/infrastructure/workload-zendesk.tf
+++ b/infrastructure/workload-zendesk.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "zendesk" {
   name     = "pins-rg-logic-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 resource "azurerm_resource_group" "zendesk_failover" {
@@ -16,7 +16,7 @@ resource "azurerm_resource_group" "zendesk_failover" {
   name     = "pins-rg-logic-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "zendesk" {
@@ -33,7 +33,7 @@ module "zendesk" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion.service_bus_primary_connection_string
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }
 
 module "zendesk_failover" {
@@ -50,5 +50,5 @@ module "zendesk_failover" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion_failover[0].service_bus_primary_connection_string
 
-  tags = merge(local.tags, local.prod_tags)
+  tags = merge(local.tags, var.environment == "prod")
 }

--- a/infrastructure/workload-zendesk.tf
+++ b/infrastructure/workload-zendesk.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "zendesk" {
   name     = "pins-rg-logic-app-${local.resource_suffix}"
   location = module.azure_region.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 resource "azurerm_resource_group" "zendesk_failover" {
@@ -16,7 +16,7 @@ resource "azurerm_resource_group" "zendesk_failover" {
   name     = "pins-rg-logic-app-${local.resource_suffix_failover}"
   location = module.azure_region.paired_location.location_cli
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "zendesk" {
@@ -33,7 +33,7 @@ module "zendesk" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion.service_bus_primary_connection_string
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }
 
 module "zendesk_failover" {
@@ -50,5 +50,5 @@ module "zendesk_failover" {
   service_name                          = local.service_name
   service_bus_primary_connection_string = module.synapse_ingestion_failover[0].service_bus_primary_connection_string
 
-  tags = local.tags
+  tags = merge(local.tags, local.prod_tags)
 }

--- a/pipelines/azure-pipelines.yaml
+++ b/pipelines/azure-pipelines.yaml
@@ -67,6 +67,11 @@ stages:
     outputsFileName: "tfoutputs.json"
     runTerraformApply: ${{ parameters.runTerraformApply }}
     refreshTFState: ${{ parameters.refreshTFState }}
+    system_asset_owner:
+      - group: system_asset_owner
+    extraEnvironmentVariables:
+      - name: TF_VAR_system_asset_owner
+        value: $(system_asset_owner)
 
 - ${{ if eq(parameters.runTerraformApply, true) }}:
   - template: stages/run-tests.yaml

--- a/pipelines/azure-pipelines.yaml
+++ b/pipelines/azure-pipelines.yaml
@@ -54,6 +54,8 @@ variables:
 - name: azureSubscription
   value: 'pins-agent-pool-odw-${{ parameters.env }}-uks'
 - group: ${{ variables.variableGroupName }}
+- name: TF_VAR_system_asset_owner
+  value: $(system_asset_owner)
 
 stages:
 - template: pipelines/stages/wait-for-approval.yaml@odw-common
@@ -67,11 +69,11 @@ stages:
     outputsFileName: "tfoutputs.json"
     runTerraformApply: ${{ parameters.runTerraformApply }}
     refreshTFState: ${{ parameters.refreshTFState }}
-    system_asset_owner:
-      - group: system_asset_owner
-    extraEnvironmentVariables:
-      - name: TF_VAR_system_asset_owner
-        value: $(system_asset_owner)
+    # extraVariables:
+    #   - group: extra_variables
+    # extraEnvironmentVariables:
+    #   - name: TF_VAR_system_asset_owner
+    #     value: $(system_asset_owner)
 
 - ${{ if eq(parameters.runTerraformApply, true) }}:
   - template: stages/run-tests.yaml

--- a/pipelines/jobs/deploy-infrastructure.yaml
+++ b/pipelines/jobs/deploy-infrastructure.yaml
@@ -75,9 +75,7 @@ jobs:
       refreshTFState: ${{ parameters.refreshTFState }}
   
   # Only deploy infrastructure if specifically requested
-  ###
   ## Terraform deployment phase
-  ###
   - ${{ if eq(parameters.runTerraformApply, true) }}:
     # Copy Terraform plan files to artifact directory
     - task: CopyFiles@2

--- a/pipelines/jobs/deploy-infrastructure.yaml
+++ b/pipelines/jobs/deploy-infrastructure.yaml
@@ -6,7 +6,7 @@ parameters:
   outputsFileName: ''
   runTerraformApply: false
   refreshTFState: false
-  extraEnvironmentVariables: []
+  extra_variables: []
 
 
 ##
@@ -17,7 +17,7 @@ jobs:
   pool: ${{ parameters.agentPool }}
   timeoutInMinutes: 0 # Max timeout
   variables:
-  - ${{ each pair in parameters.extraEnvironmentVariables }}:
+  - ${{ each pair in parameters.extra_variables }}:
     - name: ${{ pair.name }}
       value: ${{ pair.value }}
   steps:

--- a/pipelines/jobs/deploy-infrastructure.yaml
+++ b/pipelines/jobs/deploy-infrastructure.yaml
@@ -55,6 +55,12 @@ jobs:
       workingDirectory: infrastructure
 
   # Run TFLint
+  - script: |
+      echo "Installing TFLint..."
+      curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+    displayName: 'Install TFLint'
+    workingDirectory: .
+
   - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/tflint-validate.yaml
     parameters:
       configFilePath: $(Build.Repository.LocalPath)/.tflint.hcl

--- a/pipelines/jobs/deploy-infrastructure.yaml
+++ b/pipelines/jobs/deploy-infrastructure.yaml
@@ -6,6 +6,7 @@ parameters:
   outputsFileName: ''
   runTerraformApply: false
   refreshTFState: false
+  extraEnvironmentVariables: []
 
 
 ##
@@ -15,6 +16,10 @@ jobs:
 - job: DeployInfrastructureJob
   pool: ${{ parameters.agentPool }}
   timeoutInMinutes: 0 # Max timeout
+  variables:
+  - ${{ each pair in parameters.extraEnvironmentVariables }}:
+    - name: ${{ pair.name }}
+      value: ${{ pair.value }}
   steps:
   ###
   # Validation phase

--- a/pipelines/stages/deploy-infrastructure.yaml
+++ b/pipelines/stages/deploy-infrastructure.yaml
@@ -6,6 +6,7 @@ parameters:
   outputsFileName: ''
   runTerraformApply: false
   refreshTFState: false
+  extraEnvironmentVariables: []
 
 ##
 # Deploy Infrastructure only if a modification has been detected in the codebase
@@ -24,3 +25,4 @@ stages:
       outputsFileName: ${{ parameters.outputsFileName }}
       runTerraformApply: ${{ parameters.runTerraformApply }}
       refreshTFState: ${{ parameters.refreshTFState }}
+      extraEnvironmentVariables: ${{ parameters.extraEnvironmentVariables }}

--- a/pipelines/stages/deploy-infrastructure.yaml
+++ b/pipelines/stages/deploy-infrastructure.yaml
@@ -7,6 +7,7 @@ parameters:
   runTerraformApply: false
   refreshTFState: false
   extraEnvironmentVariables: []
+  system_asset_owner: []
 
 ##
 # Deploy Infrastructure only if a modification has been detected in the codebase
@@ -15,6 +16,7 @@ stages:
 - stage: DeployInfrastructure
   displayName: 'Deploy Infrastructure to the ${{ parameters.env }} environment'
   condition: not(or(failed(), canceled()))
+  variables: ${{ parameters.system_asset_owner }}
   jobs:
   - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/jobs/deploy-infrastructure.yaml
     parameters:

--- a/pipelines/steps/terraform-plan.yaml
+++ b/pipelines/steps/terraform-plan.yaml
@@ -52,6 +52,7 @@ steps:
         -var "purview_event_hub_id"=$(PURVIEW_EVENT_HUB_ID) \
         -var "purview_event_hub_fqdn=$(PURVIEW_EVENT_HUB_FQDN)" \
         -var "purview_msi_id"=$(PURVIEW_MSI_ID) \
+        -var "system_asset_owner=$(system_asset_owner)" \
         -var "specialist_case_validation_check_recipients"="$(SPECIALIST_CASE_VALIDATION_CHECK_RECIPIENTS)" \
         -input=false \
         -out=${{ parameters.planFileName }} \


### PR DESCRIPTION
[Tags from the spreadsheet](https://pinso365.sharepoint.com/:x:/r/sites/DDS-InformationSecurityService/_layouts/15/Doc.aspx?sourcedoc=%7B4950EFC0-2445-478F-94FC-C459793CA55A%7D&file=[Azure-ODW-Prod_20260701.xlsx](https://pinso365.sharepoint.com/:x:/r/sites/DDS-InformationSecurityService/_layouts/15/Doc.aspx?sourcedoc=%7B4950EFC0-2445-478F-94FC-C459793CA55A%7D&file=Azure-ODW-Prod_20260701.xlsx&fromShare=true&action=default&mobileredirect=true)&fromShare=true&action=default&mobileredirect=true):


**Every resource in this PR according to the spreadsheet will have these exact values** Therefore, every locals.tf file will have these values

- BusinessProcess = "ODW"
- PersonalData = "No"
- SpecialCategoryData = "No"
- ProtectiveMarking = "Official-Sensitive-Mission-Critical"
- CriticalityRating = "Level 2" 

---
When there are differences it is for storage accounts that are not in this PR.

- PersonalData = "Yes" only for storage accounts that can be done in another PR
- SpecialCategoryData = "Yes" only for `pins-synw-odw-prod-uks`


---

Azure pipeline will make use of the ADO secret, similar to how crown was done. and referenced into the vars files.
```json
variable "system_asset_owner" {
  description = "tagging - value extracted from ADO library secret"
  type        = string
  sensitive   = true
}
```
