### PR TITLE
Re-enable the FunctionAppLogs diagnostic category - 3439

### DIFF
--- a/infrastructure/modules/synapse-monitoring/monitor-function-app.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-function-app.tf
@@ -5,6 +5,9 @@ resource "azurerm_monitor_diagnostic_setting" "function_app" {
   target_resource_id         = each.value
   log_analytics_workspace_id = azurerm_log_analytics_workspace.synapse.id
 
+  enabled_log {
+    category = "FunctionAppLogs"
+  }
 
   metric {
     category = "AllMetrics"


### PR DESCRIPTION
Ticket : https://pins-ds.atlassian.net/browse/THEODW-3439

Tasks performed:
  I was to re-enable the code that got deleted as part of PR-176 in odw-infrastructure repo as per the need raised by ticket number 3439.