### PR TITLE
fix(infrastructure): creating system owner tags

### DIFF
--- a/infrastructure/modules/synapse-workspace-private/locals.tf
+++ b/infrastructure/modules/synapse-workspace-private/locals.tf
@@ -10,7 +10,15 @@ locals {
     var.tags,
     {
       ModuleName = local.module_name
-    }
+    },
+    var.environment == "prod" ? {
+      SystemAssetOwner    = var.system_asset_owner,
+      BusinessProcess     = "ODW"
+      PersonalData        = "No"
+      SpecialCategoryData = "No"
+      ProtectiveMarking   = "Official-Sensitive-Mission-Critical"
+      CriticalityRating   = "Level 2"
+    } : {}
   )
 
   cbos_sql_mpe = var.environment == "dev" ? {

--- a/infrastructure/modules/synapse-workspace-private/variables.tf
+++ b/infrastructure/modules/synapse-workspace-private/variables.tf
@@ -245,6 +245,13 @@ variable "synapse_sql_administrator_username" {
   type        = string
 }
 
+variable "system_asset_owner" {
+  description = "tagging - value extracted from ADO library secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "tags" {
   default     = {}
   description = "A collection of tags to assign to taggable resources"

--- a/pipelines/terraform-cd.yaml
+++ b/pipelines/terraform-cd.yaml
@@ -69,6 +69,9 @@ extends:
         value: $(PURVIEW_MSI_ID)
       - name: TF_VAR_specialist_case_validation_check_recipients
         value: $(SPECIALIST_CASE_VALIDATION_CHECK_RECIPIENTS)
+    extraVariables:
+      - group: azure_tagging_variables 
+    extraEnvironmentVariables:
       - name: TF_VAR_system_asset_owner
         value: $(system_asset_owner)
     applyStageVariableGroupFormatString: Terraform {0}

--- a/pipelines/terraform-cd.yaml
+++ b/pipelines/terraform-cd.yaml
@@ -69,9 +69,6 @@ extends:
         value: $(PURVIEW_MSI_ID)
       - name: TF_VAR_specialist_case_validation_check_recipients
         value: $(SPECIALIST_CASE_VALIDATION_CHECK_RECIPIENTS)
-    extraVariables:
-      - group: azure_tagging_variables 
-    extraEnvironmentVariables:
       - name: TF_VAR_system_asset_owner
         value: $(system_asset_owner)
     applyStageVariableGroupFormatString: Terraform {0}

--- a/pipelines/terraform-cd.yaml
+++ b/pipelines/terraform-cd.yaml
@@ -69,9 +69,6 @@ extends:
         value: $(PURVIEW_MSI_ID)
       - name: TF_VAR_specialist_case_validation_check_recipients
         value: $(SPECIALIST_CASE_VALIDATION_CHECK_RECIPIENTS)
-    extraVariables:
-      - group: extra_variables
-    extraEnvironmentVariables:
       - name: TF_VAR_system_asset_owner
         value: $(system_asset_owner)
     applyStageVariableGroupFormatString: Terraform {0}

--- a/pipelines/terraform-cd.yaml
+++ b/pipelines/terraform-cd.yaml
@@ -69,6 +69,9 @@ extends:
         value: $(PURVIEW_MSI_ID)
       - name: TF_VAR_specialist_case_validation_check_recipients
         value: $(SPECIALIST_CASE_VALIDATION_CHECK_RECIPIENTS)
+    extraVariables:
+      - group: extra_variables
+    extraEnvironmentVariables:
       - name: TF_VAR_system_asset_owner
         value: $(system_asset_owner)
     applyStageVariableGroupFormatString: Terraform {0}


### PR DESCRIPTION
I don't think this PR is needed to the pipeline if the plan works ok, but also may not know until the apply is run? I can test in template app
I believe I previously tested in devops test app which was on an older version of common pipelines so wasn't using the `planStageExtraEnvironmentVariables`